### PR TITLE
Fix gcc issue where reading depfile masked compiler errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "esmakefile-cmake",
-	"version": "0.1.1",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "esmakefile-cmake",
-			"version": "0.1.1",
+			"version": "0.1.3",
 			"license": "GPL-2.1-or-later",
 			"dependencies": {
 				"esmakefile": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "esmakefile-cmake",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Integrate esmakefile with CMake",
 	"type": "module",
 	"exports": "./dist/index.js",

--- a/src/GccCompiler.ts
+++ b/src/GccCompiler.ts
@@ -154,12 +154,16 @@ export class GccCompiler implements ICompiler {
 					deps,
 				]);
 
+				if (!result) {
+					return false;
+				}
+
 				const depfileContents = await readFile(deps, 'utf8');
 				for (const p of parsePrereqs(depfileContents)) {
 					args.addPostreq(p);
 				}
 
-				return result;
+				return true;
 			});
 		}
 


### PR DESCRIPTION
The source branch name is a misnomer. The PR is accurate. See title and fixed issue in commit message