### PR TITLE
27 allow building test tool not unit test

### DIFF
--- a/project.vim
+++ b/project.vim
@@ -14,3 +14,26 @@ augroup esmakefilecmake
 	autocmd!
 	autocmd BufNewFile *.ts :0r <sfile>:h/vim/templates/skeleton.ts
 augroup END
+
+" Automatically attempt to set CLANG_CHECK
+if empty($CLANG_CHECK)
+if has('win32')
+	" Windows
+	echo "WARNING! Update project.vim to set CLANG_CHECK=%ProgramFiles%\\LLVM\\bin\\clang-check.exe for Windows"
+else
+	let uname = trim(system('uname'))
+	if uname == 'Darwin'
+		" macOS
+		let llvm = trim(system('brew --prefix llvm'))
+		let clangCheck = llvm . '/bin/clang-check'
+		if executable(clangCheck)
+			let $CLANG_CHECK = clangCheck
+		else
+			echo "WARNING! Make sure clang-check is installed and set the CLANG_CHECK environment variable"
+		endif
+	else
+		" Linux
+		echo "WARNING! Update project.vim to set CLANG_CHECK=/usr/bin/clang-check-18 for Linux"
+	endif
+endif
+endif

--- a/src/Distribution.ts
+++ b/src/Distribution.ts
@@ -81,6 +81,9 @@ export interface IAddTestOpts extends IAddExecutableOpts {}
 export interface ITest {
 	/** Target that, when updated, runs the test executable */
 	run: IBuildPath;
+
+	/** Path to the built binary of the test executable */
+	binary: IBuildPath;
 }
 
 /**
@@ -299,7 +302,7 @@ export class Distribution {
 
 		this.make.add(this.test, [run]);
 
-		return { run };
+		return { run, binary: exe.binary };
 	}
 
 	/**

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -727,6 +727,38 @@ describe('Distribution', function () {
 			await updateTarget(make, 'test-add');
 		});
 
+		it('has access to unit test executable via binary', async () => {
+			await mkdir(join(testDir, 'test'));
+			await writePath('include/add.h', 'int add(int a, int b);');
+			await writePath('src/add.c', 'int add(int a, int b) { return a + b; }');
+
+			await writePath(
+				'test/add_test.c',
+				'#include "add.h"',
+				'int main() {',
+				'return add(2,2) != 4;',
+				'}',
+			);
+
+			const d = new Distribution(make, {
+				name: 'add',
+				version: '1.2.3',
+			});
+
+			const add = d.addLibrary({
+				name: 'add',
+				src: ['src/add.c'],
+			});
+
+			const { binary } = d.addTest({
+				name: 'add_test',
+				src: ['test/add_test.c'],
+				linkTo: [add],
+			});
+
+			await expectOutput(binary, '');
+		});
+
 		describe('static vs dynamic', () => {
 			beforeEach(async () => {
 				await writePath(

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -999,7 +999,10 @@ describe('Distribution', function () {
 			await updateTarget(make, commands);
 
 			const clangCheck = process.env['CLANG_CHECK'];
-			expect(clangCheck).not.to.be.empty;
+			expect(
+				clangCheck,
+				'the CLANG_CHECK environment variable should be specified, but is not',
+			).not.to.be.empty;
 			await run(clangCheck, [
 				'-p',
 				make.buildRoot,


### PR DESCRIPTION
This added functionality so that test objects returned from `addTest` expose the executable's `binary`. For a test executable that may be run manually by a user, this is convenient for having the test

- excluded from the distribution that users would install
- avoids an alternative like telling `addExecutable` that the executable _shouldn't_ be added to the `Distribution`, which is counterintuitive

I also took a chance to clean up some of the `CLANG_CHECK` environment variable setting in `project.vim`, but this will only impact the development environment for this project.