### PR TITLE
Test maintenance

### DIFF
--- a/project.vim
+++ b/project.vim
@@ -17,33 +17,24 @@ augroup END
 
 " Automatically attempt to set CLANG_CHECK
 if empty($CLANG_CHECK)
-if has('win32')
-	" Windows
-	let clangCheck = $ProgramFiles . '\LLVM\bin\clang-check.exe'
-		if executable(clangCheck)
-			let $CLANG_CHECK = clangCheck
-		else
-			echo "WARNING! Make sure clang-check is installed and set the CLANG_CHECK environment variable"
-		endif
-else
-	let uname = trim(system('uname'))
-	if uname == 'Darwin'
-		" macOS
-		let llvm = trim(system('brew --prefix llvm'))
-		let clangCheck = llvm . '/bin/clang-check'
-		if executable(clangCheck)
-			let $CLANG_CHECK = clangCheck
-		else
-			echo "WARNING! Make sure clang-check is installed and set the CLANG_CHECK environment variable"
-		endif
+	let clangCheck = ''
+	if has('win32')
+		" Windows
+		let clangCheck = $ProgramFiles . '\LLVM\bin\clang-check.exe'
 	else
-		" Linux
-		let clangCheck = trim(system('which clang-check-18'))
-		if executable(clangCheck)
-			let $CLANG_CHECK = clangCheck
-		else
-			echo "WARNING! Make sure clang-check is installed and set the CLANG_CHECK environment variable"
+		let uname = trim(system('uname'))
+		if uname == 'Darwin'
+			" macOS
+			let llvm = trim(system('brew --prefix llvm'))
+			let clangCheck = llvm . '/bin/clang-check'
+		elseif uname == 'Linux'
+			" Linux
+			let clangCheck = trim(system('which clang-check-18'))
 		endif
 	endif
-endif
+	if executable(clangCheck)
+		let $CLANG_CHECK = clangCheck
+	else
+		echo "WARNING! Make sure clang-check is installed and set the CLANG_CHECK environment variable"
+	endif
 endif

--- a/project.vim
+++ b/project.vim
@@ -38,7 +38,12 @@ else
 		endif
 	else
 		" Linux
-		echo "WARNING! Update project.vim to set CLANG_CHECK=/usr/bin/clang-check-18 for Linux"
+		let clangCheck = trim(system('which clang-check-18'))
+		if executable(clangCheck)
+			let $CLANG_CHECK = clangCheck
+		else
+			echo "WARNING! Make sure clang-check is installed and set the CLANG_CHECK environment variable"
+		endif
 	endif
 endif
 endif

--- a/project.vim
+++ b/project.vim
@@ -19,7 +19,12 @@ augroup END
 if empty($CLANG_CHECK)
 if has('win32')
 	" Windows
-	echo "WARNING! Update project.vim to set CLANG_CHECK=%ProgramFiles%\\LLVM\\bin\\clang-check.exe for Windows"
+	let clangCheck = $ProgramFiles . '\LLVM\bin\clang-check.exe'
+		if executable(clangCheck)
+			let $CLANG_CHECK = clangCheck
+		else
+			echo "WARNING! Make sure clang-check is installed and set the CLANG_CHECK environment variable"
+		endif
 else
 	let uname = trim(system('uname'))
 	if uname == 'Darwin'

--- a/project.vim
+++ b/project.vim
@@ -1,7 +1,7 @@
-set path=.
-set path+=src
-set path+=src/spec
-set path+=.github/workflows
+set path=., " current file's directory and current directory
+set path+=src/**
+set path+=.github/**
+set path+=vim/**
 
 nnoremap <Leader>b :!npm run build<CR>
 nnoremap <Leader>d :!npx mocha --inspect-brk -- dist/spec<CR>

--- a/src/spec/cmake.ts
+++ b/src/spec/cmake.ts
@@ -18,6 +18,7 @@
  */
 
 import { run } from './run.js';
+import { platform } from 'node:os';
 
 interface ICMakeConfigureOpts {
 	src: string;
@@ -47,7 +48,14 @@ interface ICMakeInstallOpts {
 	 */
 class CMake {
 	public configure(opts: ICMakeConfigureOpts): Promise<void> {
+		const generator = [];
+		if (platform() === 'win32') {
+			// so much faster than msbuild. Ideally would test msbuild, but not fast enough for quick testing
+			generator.push('-G', 'Ninja');
+		}
+
 		return run('cmake', [
+			...generator,
 			'-B',
 			opts.build,
 			'-S',


### PR DESCRIPTION
This updated some simple test maintenance stuff.

1. Windows CMake now uses the `Ninja` generator to speed things up
2. Windows and Linux's `project.vim` now automatically sets the `CLANG_CHECK` environment variable
3. Improve `path` in `project.vim` to include current directory. Not specific to tests, but useful anyways