### PR TITLE
30 improve test structure

### DIFF
--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         runner:
           - os: macos-latest
-            clang-check: /opt/homebrew/opt/llvm@15/bin/clang-check
+            clang-check: /opt/homebrew/opt/llvm@18/bin/clang-check
           - os: ubuntu-latest
             clang-check: /usr/bin/clang-check-18
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ types
 scratch
 esmakefile-cmake-*.tgz
 source.tgz
+vendor

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ tsconfig.json
 types/spec
 src/spec
 dist/spec
+test-plan.md

--- a/README.md
+++ b/README.md
@@ -123,3 +123,4 @@ above. While tailored solutions inspecting library types
 and which flags to specifically include could be done,
 it is currently out of scope due to the anticipated
 frequency of this being a problem.
+

--- a/README.md
+++ b/README.md
@@ -123,4 +123,3 @@ above. While tailored solutions inspecting library types
 and which flags to specifically include could be done,
 it is currently out of scope due to the anticipated
 frequency of this being a problem.
-

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,0 +1,7 @@
+# `dev-docs`
+
+This directory is inteded for documentation about
+dev process in this project that should not be
+published with a release. It only affects dev process
+and does not impact how users would interact with a
+distribution.

--- a/dev-docs/testing/README.md
+++ b/dev-docs/testing/README.md
@@ -1,0 +1,47 @@
+# Testing Strategy
+
+Due to the complex integrated nature of this project, automated
+testing is somewhat challenging to accomplish via normal unit
+tests alone. Instead, integration tests are heavily relied on.
+
+The entry point for testing can be found in `src/spec/e2e.ts`
+and should be the source of truth for _how_ tests are run.
+
+The inteded test cases should all be documented in
+`src/spec/plan.yaml` with IDs and descriptions of features being
+tested. They are organized based on the outputs of
+`esmakefile-cmake`.
+
+1. `dev`: Development Builds
+
+   The development builds are tested by programmatically
+   generating C/C++ source and building with `esmakefile` by
+   running `node`. The compiled outputs are run and tested to
+   ensure that `esmakefile-cmake` is behaving properly as a
+   development environment.
+
+2. `dist`: Generated Distribution
+
+   The generated distribution is what a developer would generate to
+   ship a release, and what a user would download when building
+   from source. It is tested by verifying the correct contents
+   exist and by building/installing with CMake to ensure things are
+   functioning properly at a basic level.
+
+3. `cm-pkg`: CMake Package
+
+   After installing a distribution that contains a library, each
+   library should generate a CMake package file such that users
+   could link to it in a `CMakeLists.txt` file by using
+   `find_package`. The generated package files are tested by
+   installing libraries and using downstream CMake projects with
+   `find_package` directives to exercise the generated package.
+
+4. `pc-pkg`: pkg-config Package
+
+   Similar to the CMake packages, a distribution with a library
+   should also install `.pc` files that are compatible with
+   `pkg-config` to link to the installed library. This is tested by
+   installing libraries and using downstream esmakefile-cmake projects
+   with `findPackage` calls to link to the installed library to
+   exercise functionality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
 				"esbuild": "^0.25.0",
 				"mocha": "^11.1.0",
 				"prettier": "^3.4.2",
-				"typescript": "^5.7.3"
+				"typescript": "^5.7.3",
+				"yaml": "^2.8.1"
 			}
 		},
 		"node_modules/@alcalzone/ansi-tokenize": {
@@ -2444,6 +2445,19 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
 			}
 		},
 		"node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"esbuild": "^0.25.0",
 		"mocha": "^11.1.0",
 		"prettier": "^3.4.2",
-		"typescript": "^5.7.3"
+		"typescript": "^5.7.3",
+		"yaml": "^2.8.1"
 	},
 	"dependencies": {
 		"esmakefile": "^0.6.2",

--- a/project.vim
+++ b/project.vim
@@ -7,6 +7,9 @@ nnoremap <Leader>b :!npm run build<CR>
 nnoremap <Leader>d :!npx mocha --inspect-brk -- dist/spec/DistributionSpec.js<CR>
 
 nnoremap <Leader>t :!npm test<CR>
+nnoremap <Leader>g :!node dist/spec/e2e.js --outdir .test pkg<CR>
+nnoremap <Leader>v :!node dist/spec/e2e.js --outdir .test dev<CR>
+
 "Use below to test specific case. Can make this better later
 "nnoremap <Leader>t :!npx mocha -f external -- dist/spec<CR>
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -54,7 +54,7 @@ export function parseConfig(config: unknown, basePath?: string): config is IConf
 					return false;
 				}
 
-				paths[i] = resolve(paths[i], basePath);
+				paths[i] = basePath ? resolve(paths[i], basePath) : resolve(paths[i]);
 			}
 		} else if (p === 'buildSharedLibs') {
 			if (typeof config[p] !== 'boolean') {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -32,7 +32,10 @@ export interface IConfig {
 // TODO this needs logging to inform user of invalid config /
 // and/or warnings
 // TODO good candidate for unit testing
-export function parseConfig(config: unknown, basePath?: string): config is IConfig {
+export function parseConfig(
+	config: unknown,
+	basePath?: string,
+): config is IConfig {
 	if (!isJsObject(config)) {
 		return false;
 	}
@@ -50,7 +53,7 @@ export function parseConfig(config: unknown, basePath?: string): config is IConf
 			}
 
 			for (let i = 0; i < paths.length; ++i) {
-				if (typeof(paths[i]) !== 'string') {
+				if (typeof paths[i] !== 'string') {
 					return false;
 				}
 
@@ -71,7 +74,9 @@ export function parseConfig(config: unknown, basePath?: string): config is IConf
 
 export function readConfigFile(path: string): IConfig | null {
 	if (!path.endsWith('.json')) {
-		throw new Error(`esmakefile-cmake config file '${path}' must have a '.json' extension`);
+		throw new Error(
+			`esmakefile-cmake config file '${path}' must have a '.json' extension`,
+		);
 	}
 
 	let contents: string;
@@ -91,11 +96,11 @@ export function readConfigFile(path: string): IConfig | null {
 }
 
 function isJsObject(value: unknown): value is Record<string, unknown> {
-	if (!(value && typeof(value) === 'object')) {
+	if (!(value && typeof value === 'object')) {
 		return false;
 	}
 
-	if (typeof(value.hasOwnProperty) !== 'function') {
+	if (typeof value.hasOwnProperty !== 'function') {
 		return false;
 	}
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 Nicholas Gulachek
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+
+import { resolve, dirname } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+/** Build-time configuration for a Distribution */
+export interface IConfig {
+	/** Additional paths to search for .pc files */
+	addPkgConfigSearchPaths?: string[];
+
+	/** Build shared libraries by default */
+	buildSharedLibs?: boolean;
+}
+
+// TODO this needs logging to inform user of invalid config /
+// and/or warnings
+// TODO good candidate for unit testing
+export function parseConfig(config: unknown, basePath?: string): config is IConfig {
+	if (!isJsObject(config)) {
+		return false;
+	}
+
+	for (const p in config) {
+		if (!config.hasOwnProperty(p)) {
+			continue;
+		}
+
+		if (p === 'addPkgConfigSearchPaths') {
+			const paths = config[p];
+
+			if (!Array.isArray(paths)) {
+				return false;
+			}
+
+			for (let i = 0; i < paths.length; ++i) {
+				if (typeof(paths[i]) !== 'string') {
+					return false;
+				}
+
+				paths[i] = resolve(paths[i], basePath);
+			}
+		} else if (p === 'buildSharedLibs') {
+			if (typeof config[p] !== 'boolean') {
+				return false;
+			}
+		} else {
+			// invalid property
+			return false;
+		}
+	}
+
+	return true;
+}
+
+export function readConfigFile(path: string): IConfig | null {
+	if (!path.endsWith('.json')) {
+		throw new Error(`esmakefile-cmake config file '${path}' must have a '.json' extension`);
+	}
+
+	let contents: string;
+
+	try {
+		contents = readFileSync(path, 'utf8');
+	} catch {
+		return null;
+	}
+
+	const obj = JSON.parse(contents);
+	if (!parseConfig(obj)) {
+		throw new Error(`esmakefile-config file '${path}' is invalid.`);
+	}
+
+	return obj;
+}
+
+function isJsObject(value: unknown): value is Record<string, unknown> {
+	if (!(value && typeof(value) === 'object')) {
+		return false;
+	}
+
+	if (typeof(value.hasOwnProperty) !== 'function') {
+		return false;
+	}
+
+	return true;
+}

--- a/src/Distribution.ts
+++ b/src/Distribution.ts
@@ -181,13 +181,13 @@ export class Distribution {
 			// TODO - this.make.abs(Path.src('pkgconfig')) for
 			// override
 			this.make.abs(Path.build('pkgconfig')),
-			resolve('vendor/lib/pkgconfig')
+			resolve('vendor/lib/pkgconfig'),
 		);
 
 		this._parseConfig();
 
 		this._pkg = new PkgConfig({
-			searchPaths: this._pkgSearchPaths
+			searchPaths: this._pkgSearchPaths,
 		});
 
 		const compilerArgs: ICompilerArgs = {

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -217,9 +217,9 @@ async function updateTarget(
 
 		await testOutput(
 			[
-				'e2e.addExecutable.source-is-prereq',
-				'e2e.addExecutable.multi-source-dev',
-				'e2e.addExecutable.default-include',
+				'e2e.dev.addExecutable.source-is-prereq',
+				'e2e.dev.addExecutable.multi-source',
+				'e2e.dev.addExecutable.default-include',
 			],
 			hello.binary,
 			'hello!',
@@ -228,7 +228,7 @@ async function updateTarget(
 		await writePath('include/punct.h', "#define PUNCT '?'");
 
 		await testOutput(
-			['e2e.addExecutable.header-is-postreq'],
+			['e2e.dev.addExecutable.header-is-postreq'],
 			hello.binary,
 			'hello?',
 		);
@@ -258,7 +258,7 @@ async function updateTarget(
 		});
 
 		await testOutput(
-			'e2e.addExecutable.links-c-cxx-as-cxx',
+			'e2e.dev.addExecutable.links-c-cxx-as-cxx',
 			hello.binary,
 			'hello!',
 		);
@@ -302,7 +302,7 @@ async function updateTarget(
 			linkTo: [nums],
 		});
 
-		await testOutput('e2e.addLibrary.links-c-cxx-as-cxx', main.binary, '2');
+		await testOutput('e2e.dev.addLibrary.links-c-cxx-as-cxx', main.binary, '2');
 	});
 
 	await test('dev4', async () => {
@@ -326,7 +326,7 @@ async function updateTarget(
 			src: ['src/printv.c'],
 		});
 
-		await testOutput('e2e.Distribution.c11-dev-exe', t.binary, '201112');
+		await testOutput('e2e.dev.Distribution.c11-exe', t.binary, '201112');
 	});
 
 	await test('dev5', async () => {
@@ -350,7 +350,7 @@ async function updateTarget(
 			src: ['src/printv.c'],
 		});
 
-		await testOutput('e2e.Distribution.c17-dev-exe', t.binary, '201710');
+		await testOutput('e2e.dev.Distribution.c17-exe', t.binary, '201710');
 	});
 
 	await test('dev6', async () => {
@@ -375,7 +375,7 @@ async function updateTarget(
 			src: ['src/printv.cpp'],
 		});
 
-		await testOutput('e2e.Distribution.cxx17-dev-exe', t.binary, '201703');
+		await testOutput('e2e.dev.Distribution.cxx17-exe', t.binary, '201703');
 	});
 
 	await test('dev7', async () => {
@@ -400,7 +400,7 @@ async function updateTarget(
 			src: ['src/printv.cpp'],
 		});
 
-		await testOutput('e2e.Distribution.cxx20-dev-exe', t.binary, '202002');
+		await testOutput('e2e.dev.Distribution.cxx20-exe', t.binary, '202002');
 	});
 
 	// compiles and links libraries

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1314,17 +1314,10 @@ describe('Distribution', function () {
 				linkTo: [notFound],
 			});
 
-			const gen = d.addExecutable({
-				name: 'gen',
-				src: [genC],
-				linkTo: [zero],
-			});
-
 			// TODO - install multiple in same call
 			d.install(printv);
 			d.install(printvxx);
 			d.install(add);
-			d.install(gen);
 			d.install(testUpstream);
 
 			await install(d);
@@ -1354,10 +1347,6 @@ describe('Distribution', function () {
 		after(async () => {
 			chdir(oldDir);
 			await rm(testDir, { recursive: true });
-		});
-
-		it('can install a target with generated source', async () => {
-			await expectOutput('vendor/bin/gen', 'generated!');
 		});
 
 		it('passes upstream checks', async () => {

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -570,8 +570,7 @@ async function updateTarget(
 		);
 	});
 
-	// fails if incompatible version specified
-	await test('fails-pkgconfig-version-incompatible', async () => {
+	await test('dev11', async () => {
 		await setupExternal();
 
 		const d = new Distribution(make, {
@@ -590,11 +589,13 @@ async function updateTarget(
 		});
 
 		const { result } = await experimental.updateTarget(make, test.binary);
-		expect(result).to.be.false;
+
+		await report('e2e.dev.findPackage.fails-incompatible-version', () => {
+			expect(result).to.be.false;
+		});
 	});
 
-	// can specify an external package for linking differently between pkgconfig and cmake
-	await test('cmake-pkgconfig-different-name', async () => {
+	await test('dev12', async () => {
 		await setupExternal();
 
 		const d = new Distribution(make, {
@@ -613,11 +614,14 @@ async function updateTarget(
 			linkTo: [addPkg],
 		});
 
-		await expectOutput(test.binary, '2+2=4');
+		await report(
+			['e2e.dev.findPackage.can-specify-explicit-pkgconfig-name'],
+			() => expectOutput(test.binary, '2+2=4'),
+		);
 	});
 
 	// can find an external package for linking to a library
-	await test('link-pkgconfig-lib', async () => {
+	await test('dev13', async () => {
 		await setupExternal();
 
 		const d = new Distribution(make, {
@@ -666,7 +670,9 @@ async function updateTarget(
 			linkTo: [mul],
 		});
 
-		await expectOutput(test.binary, '2*3=6');
+		await report('e2e.dev.findPackage.can-link-to-lib', () =>
+			expectOutput(test.binary, '2*3=6'),
+		);
 	});
 
 	// can specify a CMake version

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -316,8 +316,7 @@ async function updateTarget(
 		await testOutput('e2e.Distribution.c11-dev-exe', t.binary, '201112');
 	});
 
-	// can specify c17
-	await test('c17-lang', async () => {
+	await test('dev5', async () => {
 		await writePath(
 			'src/printv.c',
 			'#include <stdio.h>',
@@ -338,7 +337,7 @@ async function updateTarget(
 			src: ['src/printv.c'],
 		});
 
-		await expectOutput(t.binary, '201710');
+		await testOutput('e2e.Distribution.c17-dev-exe', t.binary, '201710');
 	});
 
 	// can specify c++17

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1298,17 +1298,6 @@ describe('Distribution', function () {
 			await rm(testDir, { recursive: true });
 		});
 
-		it('does not install a test', () => {
-			// first check printv to make sure we're in the right directory (avoid success by accident)
-			if (platform() === 'win32') {
-				expect(existsSync('vendor\\bin\\printv.exe')).to.be.true;
-				expect(existsSync('vendor\\bin\\unit_test.exe')).to.be.false;
-			} else {
-				expect(existsSync('vendor/bin/printv')).to.be.true;
-				expect(existsSync('vendor/bin/unit_test')).to.be.false;
-			}
-		});
-
 		it('copies expected files to distribution', () => {
 			// just to make sure we're in right cwd
 			const result = spawnSync('tar', ['tfz', make.abs(distArchive)], {

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1132,23 +1132,6 @@ describe('Distribution', function () {
 
 			await writePath('LICENSE.txt', 'This is a test license!');
 
-			// add a silly package in pkg-config and cmake that
-			// defines ZERO
-			await writePath(
-				'vendor/lib/pkgconfig/zero.pc',
-				'Name: zero',
-				'Version: 0',
-				'Description: nada',
-				'Cflags: -DZERO=0',
-			);
-
-			await mkdir(join(cmakeDir, 'zero'));
-			await writePath(
-				'vendor/lib/cmake/zero/zero-config.cmake',
-				'add_library(zero INTERFACE)',
-				'target_compile_definitions(zero INTERFACE ZERO=0)',
-			);
-
 			await writePath(
 				'src/printv.c',
 				'#include <stdio.h>',

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -90,9 +90,9 @@ async function updateTarget(
 		console.warn('Warning:', w.msg);
 	}
 
-	expect(result).to.be.true;
 	expect(errors.length).to.equal(0);
 	expect(warnings.length).to.equal(0);
+	expect(result).to.be.true;
 }
 
 (async function () {
@@ -221,8 +221,7 @@ async function updateTarget(
 		);
 	});
 
-	// links mixed c/c++ as a c++ executable
-	await test('mixed-lang-exe', async () => {
+	await test('dev2', async () => {
 		await writePath(
 			'src/hello.cpp',
 			'#include <iostream>',
@@ -245,7 +244,11 @@ async function updateTarget(
 			src: ['src/main.c', 'src/hello.cpp'],
 		});
 
-		await expectOutput(hello.binary, 'hello!');
+		await testOutput(
+			'e2e.addExecutable.links-c-cxx-as-cxx',
+			hello.binary,
+			'hello!',
+		);
 	});
 
 	// links mixed c/c++ as a c++ library

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -32,12 +32,7 @@ import { spawnSync } from 'node:child_process';
 import { chdir, cwd } from 'node:process';
 import { run } from './run.js';
 
-const testDir = resolve('.test');
-const srcDir = join(testDir, 'src');
-const buildDir = join(testDir, 'build');
-const includeDir = join(testDir, 'include');
-const vendorDir = join(testDir, 'vendor');
-const pkgconfigDir = join(vendorDir, 'lib', 'pkgconfig');
+const globalTestDir = join(resolve('.test'), 'dev');
 
 async function updateTarget(
 	make: Makefile,
@@ -72,6 +67,12 @@ async function updateTarget(
 describe('Distribution', function () {
 	this.timeout(30000); // give some time for compiler
 	let make: Makefile;
+	let testDir: string;
+	let srcDir: string;
+	let buildDir: string;
+	let includeDir: string;
+	let vendorDir: string;
+	let pkgconfigDir: string;
 
 	const allNames = new Set<string>();
 
@@ -82,20 +83,27 @@ describe('Distribution', function () {
 		allNames.add(name);
 
 		it(name, async () => {
-			make = new Makefile({
-				srcRoot: testDir,
-				buildRoot: buildDir,
-			});
+			testDir = join(globalTestDir, name);
+			srcDir = join(testDir, 'src');
+			buildDir = join(testDir, 'build');
+			includeDir = join(testDir, 'include');
+			vendorDir = join(testDir, 'vendor');
+			pkgconfigDir = join(vendorDir, 'lib', 'pkgconfig');
 
+			await mkdir(testDir, { recursive: true });
 			await mkdir(includeDir, { recursive: true });
 			await mkdir(srcDir, { recursive: true });
 			const prevDir = cwd();
 			chdir(testDir);
 
+			make = new Makefile({
+				srcRoot: testDir,
+				buildRoot: buildDir,
+			});
+
 			await impl();
 
 			chdir(prevDir);
-			await rm(testDir, { recursive: true });
 		});
 	}
 

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -993,9 +993,9 @@ describe('Distribution', function () {
 
 			it('is dynamic when default is set to dynamic', async () => {
 				await writePath(
-					'test-config.json',
+					'esmakefile-cmake.config.json',
 					JSON.stringify({
-						'build-shared-libs': true,
+						buildSharedLibs: true,
 					}),
 				);
 
@@ -1020,9 +1020,9 @@ describe('Distribution', function () {
 
 			it('is dynamic when default is set to dynamic and library has explicit default type', async () => {
 				await writePath(
-					'test-config.json',
+					'esmakefile-cmake.config.json',
 					JSON.stringify({
-						'build-shared-libs': true,
+						buildSharedLibs: true,
 					}),
 				);
 

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -26,7 +26,6 @@ import {
 	BuildPathLike,
 } from 'esmakefile';
 import { mkdir, rm, writeFile, readFile, cp } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { platform } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -141,7 +140,6 @@ describe('Distribution', function () {
 	}
 
 	describe('development', () => {
-
 		// builds a single file executable
 		test('single-file-exe', async () => {
 			await writePath(

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1210,23 +1210,6 @@ describe('Distribution', function () {
 				'int add(int a, int b) { return one() * (a + b); }',
 			);
 
-			await writePath(
-				'src/test_upstream.c',
-				'#include <two.h>',
-				'#include <hello.h>',
-				'#include <world.h>',
-				'#include <assert.h>',
-				'#include <stdio.h>',
-				'#include <string.h>',
-				'int main() {',
-				' assert(two()+two() == 4);',
-				' assert(strcmp(hello(), "hello") == 0);',
-				' assert(strcmp(world(), "world") == 0);',
-				' printf("success!");',
-				'	return 0;',
-				'}',
-			);
-
 			await writePath('src/unit_test.c', 'int main() { return 0; }');
 
 			const genC = Path.build('gen.c');
@@ -1251,37 +1234,10 @@ describe('Distribution', function () {
 			distArchive = d.dist;
 
 			const notFound = d.findPackage('not-found');
-			const zero = d.findPackage('zero');
+
 			const one = d.findPackage({
 				pkgconfig: 'libone',
 				cmake: 'one',
-			});
-
-			const two = d.findPackage({
-				pkgconfig: 'two',
-				cmake: {
-					packageName: 'Two2',
-					version: '2',
-					libraryTarget: 'two',
-				},
-			});
-
-			const hello = d.findPackage({
-				pkgconfig: 'hello',
-				cmake: {
-					packageName: 'HelloWorld',
-					component: 'hello',
-					libraryTarget: 'HelloWorld::hello',
-				},
-			});
-
-			const world = d.findPackage({
-				pkgconfig: 'world',
-				cmake: {
-					packageName: 'HelloWorld',
-					component: 'world',
-					libraryTarget: 'HelloWorld::world',
-				},
 			});
 
 			const printv = d.addExecutable({
@@ -1300,12 +1256,6 @@ describe('Distribution', function () {
 				linkTo: [one],
 			});
 
-			const testUpstream = d.addExecutable({
-				name: 'test_upstream',
-				src: ['src/test_upstream.c'],
-				linkTo: [two, hello, world],
-			});
-
 			d.addTest({
 				name: 'unit_test',
 				src: ['src/unit_test.c'],
@@ -1318,7 +1268,6 @@ describe('Distribution', function () {
 			d.install(printv);
 			d.install(printvxx);
 			d.install(add);
-			d.install(testUpstream);
 
 			await install(d);
 
@@ -1347,10 +1296,6 @@ describe('Distribution', function () {
 		after(async () => {
 			chdir(oldDir);
 			await rm(testDir, { recursive: true });
-		});
-
-		it('passes upstream checks', async () => {
-			await expectOutput('vendor/bin/test_upstream', 'success!');
 		});
 
 		it('does not install a test', () => {

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1293,33 +1293,6 @@ describe('Distribution', function () {
 			await rm(testDir, { recursive: true });
 		});
 
-		it('installs a library w/ pkgconfig', async () => {
-			await writePath(
-				'src/print.c',
-				'#include <stdio.h>',
-				'#include <times2.h>',
-				'int main() {',
-				'printf("2*3=%d", times2(3));',
-				'return 0;',
-				'}',
-			);
-
-			const d = new Distribution(make, {
-				name: 'math',
-				version: '1.1.1',
-			});
-
-			const add = d.findPackage('times2');
-
-			const print = d.addExecutable({
-				name: 'print',
-				src: ['src/print.c'],
-				linkTo: [add],
-			});
-
-			await expectOutput(print.binary, '2*3=6');
-		});
-
 		it('installs a CMake package for library', async () => {
 			await writePath(
 				'src/print.c',

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -122,1031 +122,1025 @@ describe('Distribution', function () {
 		expect(stdout).to.equal(output);
 	}
 
-	describe('development', () => {
-		// builds a single file executable
-		test('single-file-exe', async () => {
-			await writePath(
-				'src/hello.c',
-				'#include <stdio.h>',
-				'int main(){ printf("hello!"); return 0; }',
-			);
+	// builds a single file executable
+	test('single-file-exe', async () => {
+		await writePath(
+			'src/hello.c',
+			'#include <stdio.h>',
+			'int main(){ printf("hello!"); return 0; }',
+		);
 
-			const d = new Distribution(make, {
-				name: 'hello',
-				version: '1.2.3',
-			});
-
-			const hello = d.addExecutable({
-				name: 'hello',
-				src: ['src/hello.c'],
-			});
-
-			await expectOutput(hello.binary, 'hello!');
+		const d = new Distribution(make, {
+			name: 'hello',
+			version: '1.2.3',
 		});
 
-		// updates when source updates
-		test('src-is-prereq', async () => {
-			await writePath(
-				'src/hello.c',
-				'#include <stdio.h>',
-				'int main(){ printf("hello!"); return 0; }',
-			);
-
-			const d = new Distribution(make, {
-				name: 'hello',
-				version: '1.2.3',
-			});
-
-			const hello = d.addExecutable({
-				name: 'hello',
-				src: ['src/hello.c'],
-			});
-
-			await expectOutput(hello.binary, 'hello!');
-
-			await writePath(
-				'src/hello.c',
-				'#include <stdio.h>',
-				'int main(){ printf("hi."); return 0; }',
-			);
-
-			await expectOutput(hello.binary, 'hi.');
+		const hello = d.addExecutable({
+			name: 'hello',
+			src: ['src/hello.c'],
 		});
 
-		// can compile multiple source file exe
-		test('multi-src-exe', async () => {
-			await writePath(
-				'src/hello.c',
-				'#include <stdio.h>',
-				'void hello(){ printf("hello!"); }',
-			);
+		await expectOutput(hello.binary, 'hello!');
+	});
 
-			await writePath(
-				'src/main.c',
-				'extern void hello();',
-				'int main(){ hello(); return 0; }',
-			);
+	// updates when source updates
+	test('src-is-prereq', async () => {
+		await writePath(
+			'src/hello.c',
+			'#include <stdio.h>',
+			'int main(){ printf("hello!"); return 0; }',
+		);
 
-			const d = new Distribution(make, {
-				name: 'hello',
-				version: '1.2.3',
-			});
-
-			const hello = d.addExecutable({
-				name: 'hello',
-				src: ['src/main.c', 'src/hello.c'],
-			});
-
-			await expectOutput(hello.binary, 'hello!');
+		const d = new Distribution(make, {
+			name: 'hello',
+			version: '1.2.3',
 		});
 
-		// links mixed c/c++ as a c++ executable
-		test('mixed-lang-exe', async () => {
-			await writePath(
-				'src/hello.cpp',
-				'#include <iostream>',
-				'extern "C" void hello(){ std::cout << "hello!"; }',
-			);
-
-			await writePath(
-				'src/main.c',
-				'extern void hello();',
-				'int main(){ hello(); return 0; }',
-			);
-
-			const d = new Distribution(make, {
-				name: 'hello',
-				version: '1.2.3',
-			});
-
-			const hello = d.addExecutable({
-				name: 'hello',
-				src: ['src/main.c', 'src/hello.cpp'],
-			});
-
-			await expectOutput(hello.binary, 'hello!');
+		const hello = d.addExecutable({
+			name: 'hello',
+			src: ['src/hello.c'],
 		});
 
-		// links mixed c/c++ as a c++ library
-		test('mixed-lang-lib', async () => {
-			await writePath(
-				'src/one.cpp',
-				'#include <string>',
-				'extern "C" int one(){ return std::stoi("1"); }',
-			);
+		await expectOutput(hello.binary, 'hello!');
 
-			await writePath(
-				'src/two.c',
-				'extern int one();',
-				...defineExport,
-				'EXPORT int two(){ return one()+one(); }',
-			);
+		await writePath(
+			'src/hello.c',
+			'#include <stdio.h>',
+			'int main(){ printf("hi."); return 0; }',
+		);
 
-			await writePath(
-				'src/main.c',
-				'#include <stdio.h>',
-				'extern int two();',
-				'int main(){ printf("%d", two()); return 0; }',
-			);
+		await expectOutput(hello.binary, 'hi.');
+	});
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
+	// can compile multiple source file exe
+	test('multi-src-exe', async () => {
+		await writePath(
+			'src/hello.c',
+			'#include <stdio.h>',
+			'void hello(){ printf("hello!"); }',
+		);
 
-			const nums = d.addLibrary({
-				name: 'nums',
-				src: ['src/two.c', 'src/one.cpp'],
-				type: LibraryType.dynamic, // make sure fully linked
-			});
+		await writePath(
+			'src/main.c',
+			'extern void hello();',
+			'int main(){ hello(); return 0; }',
+		);
 
-			const main = d.addExecutable({
-				name: 'main',
-				src: ['src/main.c'],
-				linkTo: [nums],
-			});
-
-			await expectOutput(main.binary, '2');
+		const d = new Distribution(make, {
+			name: 'hello',
+			version: '1.2.3',
 		});
 
-		// can specify c11
-		test('c11-lang', async () => {
-			await writePath(
-				'src/printv.c',
-				'#include <stdio.h>',
-				'int main(){',
-				'printf("%ld", __STDC_VERSION__);',
-				'return 0;',
-				'}',
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-				cStd: 11,
-			});
-
-			const t = d.addExecutable({
-				name: 'printv',
-				src: ['src/printv.c'],
-			});
-
-			await expectOutput(t.binary, '201112');
+		const hello = d.addExecutable({
+			name: 'hello',
+			src: ['src/main.c', 'src/hello.c'],
 		});
 
-		// can specify c17
-		test('c17-lang', async () => {
-			await writePath(
-				'src/printv.c',
-				'#include <stdio.h>',
-				'int main(){',
-				'printf("%ld", __STDC_VERSION__);',
-				'return 0;',
-				'}',
-			);
+		await expectOutput(hello.binary, 'hello!');
+	});
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-				cStd: 17,
-			});
+	// links mixed c/c++ as a c++ executable
+	test('mixed-lang-exe', async () => {
+		await writePath(
+			'src/hello.cpp',
+			'#include <iostream>',
+			'extern "C" void hello(){ std::cout << "hello!"; }',
+		);
 
-			const t = d.addExecutable({
-				name: 'printv',
-				src: ['src/printv.c'],
-			});
+		await writePath(
+			'src/main.c',
+			'extern void hello();',
+			'int main(){ hello(); return 0; }',
+		);
 
-			await expectOutput(t.binary, '201710');
+		const d = new Distribution(make, {
+			name: 'hello',
+			version: '1.2.3',
 		});
 
-		// can specify c++17
-		test('cxx17-lang', async () => {
-			await writePath(
-				'src/printv.cpp',
-				'#include <cstdio>',
-				...cxxLangMacro,
-				'int main(){',
-				'std::printf("%ld", CXXLANG);',
-				'return 0;',
-				'}',
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-				cxxStd: 17,
-			});
-
-			const t = d.addExecutable({
-				name: 'printv',
-				src: ['src/printv.cpp'],
-			});
-
-			await expectOutput(t.binary, '201703');
+		const hello = d.addExecutable({
+			name: 'hello',
+			src: ['src/main.c', 'src/hello.cpp'],
 		});
 
-		// can specify c++20
-		test('cxx20-lang', async () => {
-			await writePath(
-				'src/printv.cpp',
-				'#include <cstdio>',
-				...cxxLangMacro,
-				'int main(){',
-				'std::printf("%ld", CXXLANG);',
-				'return 0;',
-				'}',
-			);
+		await expectOutput(hello.binary, 'hello!');
+	});
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-				cxxStd: 20,
-			});
+	// links mixed c/c++ as a c++ library
+	test('mixed-lang-lib', async () => {
+		await writePath(
+			'src/one.cpp',
+			'#include <string>',
+			'extern "C" int one(){ return std::stoi("1"); }',
+		);
 
-			const t = d.addExecutable({
-				name: 'printv',
-				src: ['src/printv.cpp'],
-			});
+		await writePath(
+			'src/two.c',
+			'extern int one();',
+			...defineExport,
+			'EXPORT int two(){ return one()+one(); }',
+		);
 
-			await expectOutput(t.binary, '202002');
+		await writePath(
+			'src/main.c',
+			'#include <stdio.h>',
+			'extern int two();',
+			'int main(){ printf("%d", two()); return 0; }',
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
 		});
 
-		// includes the "include" dir by default
-		test('default-include', async () => {
-			await writePath('include/val.h', '#define VAL 4');
-
-			await writePath(
-				'src/main.c',
-				'#include "val.h"',
-				'#include <stdio.h>',
-				'int main(){ printf("%d", VAL); return 0; }',
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const hello = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-			});
-
-			await expectOutput(hello.binary, '4');
+		const nums = d.addLibrary({
+			name: 'nums',
+			src: ['src/two.c', 'src/one.cpp'],
+			type: LibraryType.dynamic, // make sure fully linked
 		});
 
-		// recompiles after updating header
-		test('header-is-postreq', async () => {
-			await writePath('include/val.h', '#define VAL 4');
-
-			await writePath(
-				'src/main.c',
-				'#include "val.h"',
-				'#include <stdio.h>',
-				'int main(){ printf("%d", VAL); return 0; }',
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const hello = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-			});
-
-			await expectOutput(hello.binary, '4');
-
-			await writePath('include/val.h', '#define VAL 5');
-			await expectOutput(hello.binary, '5');
+		const main = d.addExecutable({
+			name: 'main',
+			src: ['src/main.c'],
+			linkTo: [nums],
 		});
 
-		// compiles and links libraries
-		test('links-transitive-lib', async () => {
-			await writePath('include/add.h', 'int add(int a, int b);');
+		await expectOutput(main.binary, '2');
+	});
 
-			await writePath('include/zero.h', 'int zero();');
-			await writePath(
-				'src/zero.c',
-				'#include "zero.h"',
-				'int zero() { return 0; }',
-			);
+	// can specify c11
+	test('c11-lang', async () => {
+		await writePath(
+			'src/printv.c',
+			'#include <stdio.h>',
+			'int main(){',
+			'printf("%ld", __STDC_VERSION__);',
+			'return 0;',
+			'}',
+		);
 
-			await writePath(
-				'src/add.c',
-				'#include "add.h"',
-				'#include "zero.h"',
-				'int add(int a, int b){ return a + b + zero(); }',
-			);
-
-			await writePath(
-				'src/main.c',
-				'#include "add.h"',
-				'#include <stdio.h>',
-				'int main(){ printf("%d", add(2,2)); return 0; }',
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const zero = d.addLibrary({
-				name: 'zero',
-				src: ['src/zero.c'],
-			});
-
-			const add = d.addLibrary({
-				name: 'add',
-				src: ['src/add.c'],
-				linkTo: [zero],
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [add],
-			});
-
-			await expectOutput(test.binary, '4');
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+			cStd: 11,
 		});
 
-		// carries includes from linked libraries
-		test('includes-dependency-header', async () => {
-			const customInclude = join(testDir, 'custom-include');
-			await mkdir(customInclude);
-
-			await writePath('custom-include/add.h', 'int add(int a, int b);');
-
-			await writePath(
-				'src/add.c',
-				'#include "add.h"',
-				'int add(int a, int b){ return a + b; }',
-			);
-
-			await writePath(
-				'src/main.c',
-				'#include "add.h"',
-				'#include <stdio.h>',
-				'int main(){ printf("%d", add(2,2)); return 0; }',
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const add = d.addLibrary({
-				name: 'add',
-				src: ['src/add.c'],
-				includeDirs: ['custom-include'],
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [add],
-			});
-
-			await expectOutput(test.binary, '4');
+		const t = d.addExecutable({
+			name: 'printv',
+			src: ['src/printv.c'],
 		});
 
-		async function setupExternal() {
-			// General strategy - build one distribution and hand-craft
-			// pkgconfig file to that distribution's build. Can test
-			// generation of installed pkgconfig in installation tests
-			await mkdir(join(testDir, 'dep', 'include'), { recursive: true });
-			await mkdir(join(testDir, 'dep', 'src'));
-			await mkdir(pkgconfigDir, { recursive: true });
+		await expectOutput(t.binary, '201112');
+	});
 
-			const dep = new Distribution(make, {
-				name: 'dep',
-				version: '2.3.4',
-			});
+	// can specify c17
+	test('c17-lang', async () => {
+		await writePath(
+			'src/printv.c',
+			'#include <stdio.h>',
+			'int main(){',
+			'printf("%ld", __STDC_VERSION__);',
+			'return 0;',
+			'}',
+		);
 
-			await writePath('dep/include/add.h', 'int add(int a, int b);');
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+			cStd: 17,
+		});
 
-			await writePath(
-				'dep/src/add.c',
-				'#include "add.h"',
-				'int add(int a, int b){ return a + b; }',
-			);
+		const t = d.addExecutable({
+			name: 'printv',
+			src: ['src/printv.c'],
+		});
 
-			const add = dep.addLibrary({
-				name: 'add',
-				src: ['dep/src/add.c'],
-				includeDirs: ['dep/include'],
-			});
+		await expectOutput(t.binary, '201710');
+	});
 
-			await updateTarget(make, add.binary);
+	// can specify c++17
+	test('cxx17-lang', async () => {
+		await writePath(
+			'src/printv.cpp',
+			'#include <cstdio>',
+			...cxxLangMacro,
+			'int main(){',
+			'std::printf("%ld", CXXLANG);',
+			'return 0;',
+			'}',
+		);
 
-			const depInclude = make.abs(Path.src('dep/include'));
-			const libDir = make.abs(add.binary.dir());
-			let cflags = `-I${depInclude}`;
-			let libs = `-L${libDir} -ladd`;
-			if (platform() === 'win32') {
-				cflags = `/I${depInclude.replace(/\\/g, '\\\\')}`;
-				libs = make.abs(add.binary).replace(/\\/g, '\\\\');
-			}
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+			cxxStd: 17,
+		});
 
-			await writePath(
-				'vendor/lib/pkgconfig/add.pc',
-				'Name: add',
-				'Version: 2.3.4',
-				'Description: add two integers',
-				`Cflags: ${cflags}`,
-				`Libs: ${libs}`,
-			);
+		const t = d.addExecutable({
+			name: 'printv',
+			src: ['src/printv.cpp'],
+		});
 
-			await writePath(
-				'src/test.c',
-				'#include <add.h>',
-				'#include <stdio.h>',
-				'int main() { printf("2+2=%d", add(2,2)); return 0; }',
-			);
+		await expectOutput(t.binary, '201703');
+	});
+
+	// can specify c++20
+	test('cxx20-lang', async () => {
+		await writePath(
+			'src/printv.cpp',
+			'#include <cstdio>',
+			...cxxLangMacro,
+			'int main(){',
+			'std::printf("%ld", CXXLANG);',
+			'return 0;',
+			'}',
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+			cxxStd: 20,
+		});
+
+		const t = d.addExecutable({
+			name: 'printv',
+			src: ['src/printv.cpp'],
+		});
+
+		await expectOutput(t.binary, '202002');
+	});
+
+	// includes the "include" dir by default
+	test('default-include', async () => {
+		await writePath('include/val.h', '#define VAL 4');
+
+		await writePath(
+			'src/main.c',
+			'#include "val.h"',
+			'#include <stdio.h>',
+			'int main(){ printf("%d", VAL); return 0; }',
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const hello = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+		});
+
+		await expectOutput(hello.binary, '4');
+	});
+
+	// recompiles after updating header
+	test('header-is-postreq', async () => {
+		await writePath('include/val.h', '#define VAL 4');
+
+		await writePath(
+			'src/main.c',
+			'#include "val.h"',
+			'#include <stdio.h>',
+			'int main(){ printf("%d", VAL); return 0; }',
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const hello = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+		});
+
+		await expectOutput(hello.binary, '4');
+
+		await writePath('include/val.h', '#define VAL 5');
+		await expectOutput(hello.binary, '5');
+	});
+
+	// compiles and links libraries
+	test('links-transitive-lib', async () => {
+		await writePath('include/add.h', 'int add(int a, int b);');
+
+		await writePath('include/zero.h', 'int zero();');
+		await writePath(
+			'src/zero.c',
+			'#include "zero.h"',
+			'int zero() { return 0; }',
+		);
+
+		await writePath(
+			'src/add.c',
+			'#include "add.h"',
+			'#include "zero.h"',
+			'int add(int a, int b){ return a + b + zero(); }',
+		);
+
+		await writePath(
+			'src/main.c',
+			'#include "add.h"',
+			'#include <stdio.h>',
+			'int main(){ printf("%d", add(2,2)); return 0; }',
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const zero = d.addLibrary({
+			name: 'zero',
+			src: ['src/zero.c'],
+		});
+
+		const add = d.addLibrary({
+			name: 'add',
+			src: ['src/add.c'],
+			linkTo: [zero],
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [add],
+		});
+
+		await expectOutput(test.binary, '4');
+	});
+
+	// carries includes from linked libraries
+	test('includes-dependency-header', async () => {
+		const customInclude = join(testDir, 'custom-include');
+		await mkdir(customInclude);
+
+		await writePath('custom-include/add.h', 'int add(int a, int b);');
+
+		await writePath(
+			'src/add.c',
+			'#include "add.h"',
+			'int add(int a, int b){ return a + b; }',
+		);
+
+		await writePath(
+			'src/main.c',
+			'#include "add.h"',
+			'#include <stdio.h>',
+			'int main(){ printf("%d", add(2,2)); return 0; }',
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const add = d.addLibrary({
+			name: 'add',
+			src: ['src/add.c'],
+			includeDirs: ['custom-include'],
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [add],
+		});
+
+		await expectOutput(test.binary, '4');
+	});
+
+	async function setupExternal() {
+		// General strategy - build one distribution and hand-craft
+		// pkgconfig file to that distribution's build. Can test
+		// generation of installed pkgconfig in installation tests
+		await mkdir(join(testDir, 'dep', 'include'), { recursive: true });
+		await mkdir(join(testDir, 'dep', 'src'));
+		await mkdir(pkgconfigDir, { recursive: true });
+
+		const dep = new Distribution(make, {
+			name: 'dep',
+			version: '2.3.4',
+		});
+
+		await writePath('dep/include/add.h', 'int add(int a, int b);');
+
+		await writePath(
+			'dep/src/add.c',
+			'#include "add.h"',
+			'int add(int a, int b){ return a + b; }',
+		);
+
+		const add = dep.addLibrary({
+			name: 'add',
+			src: ['dep/src/add.c'],
+			includeDirs: ['dep/include'],
+		});
+
+		await updateTarget(make, add.binary);
+
+		const depInclude = make.abs(Path.src('dep/include'));
+		const libDir = make.abs(add.binary.dir());
+		let cflags = `-I${depInclude}`;
+		let libs = `-L${libDir} -ladd`;
+		if (platform() === 'win32') {
+			cflags = `/I${depInclude.replace(/\\/g, '\\\\')}`;
+			libs = make.abs(add.binary).replace(/\\/g, '\\\\');
 		}
 
-		// can find an external package for linking
-		test('link-pkgconfig', async () => {
-			await setupExternal();
+		await writePath(
+			'vendor/lib/pkgconfig/add.pc',
+			'Name: add',
+			'Version: 2.3.4',
+			'Description: add two integers',
+			`Cflags: ${cflags}`,
+			`Libs: ${libs}`,
+		);
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
+		await writePath(
+			'src/test.c',
+			'#include <add.h>',
+			'#include <stdio.h>',
+			'int main() { printf("2+2=%d", add(2,2)); return 0; }',
+		);
+	}
 
-			const addPkg = d.findPackage('add');
+	// can find an external package for linking
+	test('link-pkgconfig', async () => {
+		await setupExternal();
 
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/test.c'],
-				linkTo: [addPkg],
-			});
-
-			await expectOutput(test.binary, '2+2=4');
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
 		});
 
-		// can specify a pkgconfig version
-		test('specify-pkgconfig-version', async () => {
-			await setupExternal();
+		const addPkg = d.findPackage('add');
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const addPkg = d.findPackage({
-				pkgconfig: 'add = 2.3.4',
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/test.c'],
-				linkTo: [addPkg],
-			});
-
-			await expectOutput(test.binary, '2+2=4');
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/test.c'],
+			linkTo: [addPkg],
 		});
 
-		// fails if incompatible version specified
-		test('fails-pkgconfig-version-incompatible', async () => {
-			await setupExternal();
+		await expectOutput(test.binary, '2+2=4');
+	});
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
+	// can specify a pkgconfig version
+	test('specify-pkgconfig-version', async () => {
+		await setupExternal();
 
-			const addPkg = d.findPackage({
-				pkgconfig: 'add < 2.3.4',
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/test.c'],
-				linkTo: [addPkg],
-			});
-
-			const { result } = await experimental.updateTarget(make, test.binary);
-			expect(result).to.be.false;
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
 		});
 
-		// can specify an external package for linking differently between pkgconfig and cmake
-		test('cmake-pkgconfig-different-name', async () => {
-			await setupExternal();
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const addPkg = d.findPackage({
-				pkgconfig: 'add',
-				cmake: 'not-used-in-test',
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/test.c'],
-				linkTo: [addPkg],
-			});
-
-			await expectOutput(test.binary, '2+2=4');
+		const addPkg = d.findPackage({
+			pkgconfig: 'add = 2.3.4',
 		});
 
-		// can find an external package for linking to a library
-		test('link-pkgconfig-lib', async () => {
-			await setupExternal();
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const addPkg = d.findPackage('add');
-
-			await writePath(
-				'include/mul.h',
-				...defineExport,
-				'EXPORT int mul(int a, int b);',
-			);
-
-			await writePath(
-				'src/mul.c',
-				'#include "mul.h"',
-				'#include <add.h>',
-				'int mul(int a, int b) {',
-				' int sum = 0;',
-				' for(int i = 0; i < a; ++i) {',
-				'  sum = add(sum, b);',
-				' }',
-				' return sum;',
-				'}',
-			);
-
-			await writePath(
-				'src/test.c',
-				'#include "mul.h"',
-				'#include <stdio.h>',
-				'int main() { printf("2*3=%d", mul(2,3)); return 0; }',
-			);
-
-			const mul = d.addLibrary({
-				name: 'mul',
-				src: ['src/mul.c'],
-				linkTo: [addPkg],
-				type: LibraryType.dynamic,
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/test.c'],
-				linkTo: [mul],
-			});
-
-			await expectOutput(test.binary, '2*3=6');
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/test.c'],
+			linkTo: [addPkg],
 		});
 
-		// can specify a CMake version
-		test('cmake-find-package-version', async () => {
-			await setupExternal();
+		await expectOutput(test.binary, '2+2=4');
+	});
 
-			await writePath('LICENSE.txt', 'Test license');
+	// fails if incompatible version specified
+	test('fails-pkgconfig-version-incompatible', async () => {
+		await setupExternal();
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const addPkg = d.findPackage({
-				pkgconfig: 'add',
-				cmake: {
-					packageName: 'add',
-					version: '2.3.4',
-					libraryTarget: 'add',
-				},
-			});
-
-			d.addExecutable({
-				name: 'test',
-				src: ['src/test.c'],
-				linkTo: [addPkg],
-			});
-
-			await updateTarget(make, d.dist);
-
-			const cmake = Path.build('test-1.2.3/CMakeLists.txt');
-			const cmakeContents = await readFile(make.abs(cmake), 'utf8');
-
-			const lines = cmakeContents.split('\n');
-			const re = /^find_package\(add\s+2.3.4\s+REQUIRED\)$/;
-			const l = lines.find((l) => l.match(re));
-
-			expect(l, 'Did not find match').not.to.be.empty;
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
 		});
 
-		// can link between distributions
-		test('cross-distribution-link', async () => {
-			await mkdir(join(testDir, 'a', 'include'), { recursive: true });
-			await mkdir(join(testDir, 'b', 'include'), { recursive: true });
+		const addPkg = d.findPackage({
+			pkgconfig: 'add < 2.3.4',
+		});
 
-			await writePath('a/include/a.h', 'char a();');
-			await writePath('a/a.c', "char a() { return 'a'; }");
-			await writePath('b/include/b.h', 'char b();');
-			await writePath(
-				'b/b.c',
-				'#include <a.h>',
-				"char b() { return 'a' + 1; }",
-			);
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/test.c'],
+			linkTo: [addPkg],
+		});
 
-			await writePath(
-				'src/main.c',
-				'#include <stdio.h>',
-				'#include <b.h>',
-				'int main() {',
-				' printf("%c", b());',
-				' return 0;',
-				'}',
-			);
+		const { result } = await experimental.updateTarget(make, test.binary);
+		expect(result).to.be.false;
+	});
 
-			const a = new Distribution(make, {
-				name: 'a',
-				version: '1.2.3',
-			});
+	// can specify an external package for linking differently between pkgconfig and cmake
+	test('cmake-pkgconfig-different-name', async () => {
+		await setupExternal();
 
-			const liba = a.addLibrary({
-				name: 'a',
-				src: ['a/a.c'],
-				includeDirs: ['a/include'],
-			});
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
 
-			const b = new Distribution(make, {
-				name: 'b',
+		const addPkg = d.findPackage({
+			pkgconfig: 'add',
+			cmake: 'not-used-in-test',
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/test.c'],
+			linkTo: [addPkg],
+		});
+
+		await expectOutput(test.binary, '2+2=4');
+	});
+
+	// can find an external package for linking to a library
+	test('link-pkgconfig-lib', async () => {
+		await setupExternal();
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const addPkg = d.findPackage('add');
+
+		await writePath(
+			'include/mul.h',
+			...defineExport,
+			'EXPORT int mul(int a, int b);',
+		);
+
+		await writePath(
+			'src/mul.c',
+			'#include "mul.h"',
+			'#include <add.h>',
+			'int mul(int a, int b) {',
+			' int sum = 0;',
+			' for(int i = 0; i < a; ++i) {',
+			'  sum = add(sum, b);',
+			' }',
+			' return sum;',
+			'}',
+		);
+
+		await writePath(
+			'src/test.c',
+			'#include "mul.h"',
+			'#include <stdio.h>',
+			'int main() { printf("2*3=%d", mul(2,3)); return 0; }',
+		);
+
+		const mul = d.addLibrary({
+			name: 'mul',
+			src: ['src/mul.c'],
+			linkTo: [addPkg],
+			type: LibraryType.dynamic,
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/test.c'],
+			linkTo: [mul],
+		});
+
+		await expectOutput(test.binary, '2*3=6');
+	});
+
+	// can specify a CMake version
+	test('cmake-find-package-version', async () => {
+		await setupExternal();
+
+		await writePath('LICENSE.txt', 'Test license');
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const addPkg = d.findPackage({
+			pkgconfig: 'add',
+			cmake: {
+				packageName: 'add',
 				version: '2.3.4',
-			});
-
-			const libb = b.addLibrary({
-				name: 'b',
-				src: ['b/b.c'],
-				includeDirs: ['b/include'],
-				linkTo: [liba],
-			});
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '3.4.5',
-			});
-
-			const main = d.addExecutable({
-				name: 'main',
-				src: ['src/main.c'],
-				linkTo: [libb],
-			});
-
-			await expectOutput(main.binary, 'b');
+				libraryTarget: 'add',
+			},
 		});
 
-		// can add a unit test executable
-		test('unit-test-run', async () => {
-			await mkdir(join(testDir, 'test'));
-			await writePath('include/add.h', 'int add(int a, int b);');
-			await writePath('src/add.c', 'int add(int a, int b) { return a + b; }');
-
-			await writePath(
-				'test/add_test.c',
-				'#include "add.h"',
-				'int main() {',
-				'return add(2,2) != 4;',
-				'}',
-			);
-
-			const d = new Distribution(make, {
-				name: 'add',
-				version: '1.2.3',
-			});
-
-			const add = d.addLibrary({
-				name: 'add',
-				src: ['src/add.c'],
-			});
-
-			const { run } = d.addTest({
-				name: 'add_test',
-				src: ['test/add_test.c'],
-				linkTo: [add],
-			});
-
-			await updateTarget(make, run);
-
-			// also make sure test-add rule works
-			await rm(buildDir, { recursive: true });
-
-			expect(d.test.rel()).to.equal('test-add');
-			await updateTarget(make, 'test-add');
+		d.addExecutable({
+			name: 'test',
+			src: ['src/test.c'],
+			linkTo: [addPkg],
 		});
 
-		// has access to unit test executable via binary
-		test('unit-test-binary', async () => {
-			await mkdir(join(testDir, 'test'));
-			await writePath('include/add.h', 'int add(int a, int b);');
-			await writePath('src/add.c', 'int add(int a, int b) { return a + b; }');
+		await updateTarget(make, d.dist);
 
-			await writePath(
-				'test/add_test.c',
-				'#include "add.h"',
-				'int main() {',
-				'return add(2,2) != 4;',
-				'}',
-			);
+		const cmake = Path.build('test-1.2.3/CMakeLists.txt');
+		const cmakeContents = await readFile(make.abs(cmake), 'utf8');
 
-			const d = new Distribution(make, {
-				name: 'add',
-				version: '1.2.3',
-			});
+		const lines = cmakeContents.split('\n');
+		const re = /^find_package\(add\s+2.3.4\s+REQUIRED\)$/;
+		const l = lines.find((l) => l.match(re));
 
-			const add = d.addLibrary({
-				name: 'add',
-				src: ['src/add.c'],
-			});
+		expect(l, 'Did not find match').not.to.be.empty;
+	});
 
-			const { binary } = d.addTest({
-				name: 'add_test',
-				src: ['test/add_test.c'],
-				linkTo: [add],
-			});
+	// can link between distributions
+	test('cross-distribution-link', async () => {
+		await mkdir(join(testDir, 'a', 'include'), { recursive: true });
+		await mkdir(join(testDir, 'b', 'include'), { recursive: true });
 
-			await expectOutput(binary, '');
+		await writePath('a/include/a.h', 'char a();');
+		await writePath('a/a.c', "char a() { return 'a'; }");
+		await writePath('b/include/b.h', 'char b();');
+		await writePath('b/b.c', '#include <a.h>', "char b() { return 'a' + 1; }");
+
+		await writePath(
+			'src/main.c',
+			'#include <stdio.h>',
+			'#include <b.h>',
+			'int main() {',
+			' printf("%c", b());',
+			' return 0;',
+			'}',
+		);
+
+		const a = new Distribution(make, {
+			name: 'a',
+			version: '1.2.3',
 		});
 
-		async function setupStaticDynamic() {
-			await writePath(
-				'include/image_name.h',
-				...defineExport,
-				'EXPORT int image_name(char *dst, int sz);',
-			);
-
-			await writePath(
-				'src/image_name.c',
-				'#ifdef __linux__',
-				'#define _GNU_SOURCE', // needed for Dl_info
-				'#endif',
-				'#include <string.h>',
-				'#include "image_name.h"',
-				'#ifdef _WIN32',
-				'#include <windows.h>',
-				'int image_name(char *dst, int sz){',
-				' HMODULE module;',
-				' GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)image_name, &module);',
-				' GetModuleFileNameA(module, dst, sz);',
-				' return 1;',
-				'}',
-				'#else',
-				'#include <dlfcn.h>',
-				'int image_name(char *dst, int sz){',
-				'	Dl_info info;',
-				'	if (dladdr(image_name, &info)){',
-				'		strlcpy(dst, info.dli_fname, sz);',
-				'		return 1;',
-				'	} else {',
-				'		return 0;',
-				'	}',
-				'}',
-				'#endif',
-			);
-
-			await writePath(
-				'src/main.c',
-				'#include "image_name.h"',
-				'#include <stdio.h>',
-				'int main(){',
-				'	char buf[1024];',
-				'	if (!image_name(buf, sizeof(buf))) return 1;',
-				'	printf("%s", buf);',
-				'	return 0;',
-				'}',
-			);
-		}
-
-		// is static by default
-		test('default-static', async () => {
-			await setupStaticDynamic();
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const img = d.addLibrary({
-				name: 'image_name',
-				src: ['src/image_name.c'],
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [img],
-			});
-
-			await expectOutput(test.binary, make.abs(test.binary));
+		const liba = a.addLibrary({
+			name: 'a',
+			src: ['a/a.c'],
+			includeDirs: ['a/include'],
 		});
 
-		// is static when explicitly set to default type
-		test('explicit-default-static', async () => {
-			await setupStaticDynamic();
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const img = d.addLibrary({
-				name: 'image_name',
-				src: ['src/image_name.c'],
-				type: LibraryType.default,
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [img],
-			});
-
-			await expectOutput(test.binary, make.abs(test.binary));
+		const b = new Distribution(make, {
+			name: 'b',
+			version: '2.3.4',
 		});
 
-		// is static when explicitly set to static
-		test('static-static', async () => {
-			await setupStaticDynamic();
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const img = d.addLibrary({
-				name: 'image_name',
-				src: ['src/image_name.c'],
-				type: LibraryType.static,
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [img],
-			});
-
-			await expectOutput(test.binary, make.abs(test.binary));
+		const libb = b.addLibrary({
+			name: 'b',
+			src: ['b/b.c'],
+			includeDirs: ['b/include'],
+			linkTo: [liba],
 		});
 
-		// is dynamic when explicitly set to dynamic
-		test('dynamic-dynamic', async () => {
-			await setupStaticDynamic();
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const img = d.addLibrary({
-				name: 'image_name',
-				src: ['src/image_name.c'],
-				type: LibraryType.dynamic,
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [img],
-			});
-
-			await expectOutput(test.binary, make.abs(img.binary));
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '3.4.5',
 		});
 
-		// is dynamic when default is set to dynamic
-		test('default-dynamic', async () => {
-			await setupStaticDynamic();
-
-			await writePath(
-				'esmakefile-cmake.config.json',
-				JSON.stringify({
-					buildSharedLibs: true,
-				}),
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const img = d.addLibrary({
-				name: 'image_name',
-				src: ['src/image_name.c'],
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [img],
-			});
-
-			await expectOutput(test.binary, make.abs(img.binary));
+		const main = d.addExecutable({
+			name: 'main',
+			src: ['src/main.c'],
+			linkTo: [libb],
 		});
 
-		// is dynamic when default is set to dynamic and library has explicit default type
-		test('explicit-default-dynamic', async () => {
-			await setupStaticDynamic();
+		await expectOutput(main.binary, 'b');
+	});
 
-			await writePath(
-				'esmakefile-cmake.config.json',
-				JSON.stringify({
-					buildSharedLibs: true,
-				}),
-			);
+	// can add a unit test executable
+	test('unit-test-run', async () => {
+		await mkdir(join(testDir, 'test'));
+		await writePath('include/add.h', 'int add(int a, int b);');
+		await writePath('src/add.c', 'int add(int a, int b) { return a + b; }');
 
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
+		await writePath(
+			'test/add_test.c',
+			'#include "add.h"',
+			'int main() {',
+			'return add(2,2) != 4;',
+			'}',
+		);
 
-			const img = d.addLibrary({
-				name: 'image_name',
-				src: ['src/image_name.c'],
-				type: LibraryType.default,
-			});
-
-			const test = d.addExecutable({
-				name: 'test',
-				src: ['src/main.c'],
-				linkTo: [img],
-			});
-
-			await expectOutput(test.binary, make.abs(img.binary));
+		const d = new Distribution(make, {
+			name: 'add',
+			version: '1.2.3',
 		});
 
-		// generates a compile_commands.json file
-		test('compile-commands', async () => {
-			await mkdir(pkgconfigDir, { recursive: true });
-
-			const add = Path.src('src/add.c');
-			const test = Path.src('src/test.c');
-
-			await writePath('include/add.h', 'int add(int a, int b);');
-
-			await writePath(
-				add,
-				'#include "add.h"',
-				'int add(int a, int b) { return a + b; }',
-			);
-
-			await writePath(
-				test,
-				'#include "add.h"',
-				'int main() { return add(TEST_FRAMEWORK_VERSION,-TEST_FRAMEWORK_VERSION); }',
-			);
-
-			await writePath(
-				'vendor/lib/pkgconfig/test-framework.pc',
-				'Name: test-framework',
-				'Version:',
-				'Description:',
-				'Cflags: -DTEST_FRAMEWORK_VERSION=123',
-			);
-
-			const d = new Distribution(make, {
-				name: 'test',
-				version: '1.2.3',
-			});
-
-			const addLib = d.addLibrary({
-				name: 'add',
-				src: [add],
-			});
-
-			const testFramework = d.findPackage('test-framework');
-
-			d.addTest({
-				name: 'test',
-				src: [test],
-				linkTo: [addLib, testFramework],
-			});
-
-			const commands = addCompileCommands(make, d);
-
-			await updateTarget(make, commands);
-
-			const clangCheck = process.env['CLANG_CHECK'];
-			expect(
-				clangCheck,
-				'the CLANG_CHECK environment variable should be specified, but is not',
-			).not.to.be.empty;
-			await run(clangCheck, [
-				'-p',
-				make.buildRoot,
-				make.abs(add),
-				make.abs(test),
-			]);
+		const add = d.addLibrary({
+			name: 'add',
+			src: ['src/add.c'],
 		});
+
+		const { run } = d.addTest({
+			name: 'add_test',
+			src: ['test/add_test.c'],
+			linkTo: [add],
+		});
+
+		await updateTarget(make, run);
+
+		// also make sure test-add rule works
+		await rm(buildDir, { recursive: true });
+
+		expect(d.test.rel()).to.equal('test-add');
+		await updateTarget(make, 'test-add');
+	});
+
+	// has access to unit test executable via binary
+	test('unit-test-binary', async () => {
+		await mkdir(join(testDir, 'test'));
+		await writePath('include/add.h', 'int add(int a, int b);');
+		await writePath('src/add.c', 'int add(int a, int b) { return a + b; }');
+
+		await writePath(
+			'test/add_test.c',
+			'#include "add.h"',
+			'int main() {',
+			'return add(2,2) != 4;',
+			'}',
+		);
+
+		const d = new Distribution(make, {
+			name: 'add',
+			version: '1.2.3',
+		});
+
+		const add = d.addLibrary({
+			name: 'add',
+			src: ['src/add.c'],
+		});
+
+		const { binary } = d.addTest({
+			name: 'add_test',
+			src: ['test/add_test.c'],
+			linkTo: [add],
+		});
+
+		await expectOutput(binary, '');
+	});
+
+	async function setupStaticDynamic() {
+		await writePath(
+			'include/image_name.h',
+			...defineExport,
+			'EXPORT int image_name(char *dst, int sz);',
+		);
+
+		await writePath(
+			'src/image_name.c',
+			'#ifdef __linux__',
+			'#define _GNU_SOURCE', // needed for Dl_info
+			'#endif',
+			'#include <string.h>',
+			'#include "image_name.h"',
+			'#ifdef _WIN32',
+			'#include <windows.h>',
+			'int image_name(char *dst, int sz){',
+			' HMODULE module;',
+			' GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)image_name, &module);',
+			' GetModuleFileNameA(module, dst, sz);',
+			' return 1;',
+			'}',
+			'#else',
+			'#include <dlfcn.h>',
+			'int image_name(char *dst, int sz){',
+			'	Dl_info info;',
+			'	if (dladdr(image_name, &info)){',
+			'		strlcpy(dst, info.dli_fname, sz);',
+			'		return 1;',
+			'	} else {',
+			'		return 0;',
+			'	}',
+			'}',
+			'#endif',
+		);
+
+		await writePath(
+			'src/main.c',
+			'#include "image_name.h"',
+			'#include <stdio.h>',
+			'int main(){',
+			'	char buf[1024];',
+			'	if (!image_name(buf, sizeof(buf))) return 1;',
+			'	printf("%s", buf);',
+			'	return 0;',
+			'}',
+		);
+	}
+
+	// is static by default
+	test('default-static', async () => {
+		await setupStaticDynamic();
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const img = d.addLibrary({
+			name: 'image_name',
+			src: ['src/image_name.c'],
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [img],
+		});
+
+		await expectOutput(test.binary, make.abs(test.binary));
+	});
+
+	// is static when explicitly set to default type
+	test('explicit-default-static', async () => {
+		await setupStaticDynamic();
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const img = d.addLibrary({
+			name: 'image_name',
+			src: ['src/image_name.c'],
+			type: LibraryType.default,
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [img],
+		});
+
+		await expectOutput(test.binary, make.abs(test.binary));
+	});
+
+	// is static when explicitly set to static
+	test('static-static', async () => {
+		await setupStaticDynamic();
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const img = d.addLibrary({
+			name: 'image_name',
+			src: ['src/image_name.c'],
+			type: LibraryType.static,
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [img],
+		});
+
+		await expectOutput(test.binary, make.abs(test.binary));
+	});
+
+	// is dynamic when explicitly set to dynamic
+	test('dynamic-dynamic', async () => {
+		await setupStaticDynamic();
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const img = d.addLibrary({
+			name: 'image_name',
+			src: ['src/image_name.c'],
+			type: LibraryType.dynamic,
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [img],
+		});
+
+		await expectOutput(test.binary, make.abs(img.binary));
+	});
+
+	// is dynamic when default is set to dynamic
+	test('default-dynamic', async () => {
+		await setupStaticDynamic();
+
+		await writePath(
+			'esmakefile-cmake.config.json',
+			JSON.stringify({
+				buildSharedLibs: true,
+			}),
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const img = d.addLibrary({
+			name: 'image_name',
+			src: ['src/image_name.c'],
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [img],
+		});
+
+		await expectOutput(test.binary, make.abs(img.binary));
+	});
+
+	// is dynamic when default is set to dynamic and library has explicit default type
+	test('explicit-default-dynamic', async () => {
+		await setupStaticDynamic();
+
+		await writePath(
+			'esmakefile-cmake.config.json',
+			JSON.stringify({
+				buildSharedLibs: true,
+			}),
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const img = d.addLibrary({
+			name: 'image_name',
+			src: ['src/image_name.c'],
+			type: LibraryType.default,
+		});
+
+		const test = d.addExecutable({
+			name: 'test',
+			src: ['src/main.c'],
+			linkTo: [img],
+		});
+
+		await expectOutput(test.binary, make.abs(img.binary));
+	});
+
+	// generates a compile_commands.json file
+	test('compile-commands', async () => {
+		await mkdir(pkgconfigDir, { recursive: true });
+
+		const add = Path.src('src/add.c');
+		const test = Path.src('src/test.c');
+
+		await writePath('include/add.h', 'int add(int a, int b);');
+
+		await writePath(
+			add,
+			'#include "add.h"',
+			'int add(int a, int b) { return a + b; }',
+		);
+
+		await writePath(
+			test,
+			'#include "add.h"',
+			'int main() { return add(TEST_FRAMEWORK_VERSION,-TEST_FRAMEWORK_VERSION); }',
+		);
+
+		await writePath(
+			'vendor/lib/pkgconfig/test-framework.pc',
+			'Name: test-framework',
+			'Version:',
+			'Description:',
+			'Cflags: -DTEST_FRAMEWORK_VERSION=123',
+		);
+
+		const d = new Distribution(make, {
+			name: 'test',
+			version: '1.2.3',
+		});
+
+		const addLib = d.addLibrary({
+			name: 'add',
+			src: [add],
+		});
+
+		const testFramework = d.findPackage('test-framework');
+
+		d.addTest({
+			name: 'test',
+			src: [test],
+			linkTo: [addLib, testFramework],
+		});
+
+		const commands = addCompileCommands(make, d);
+
+		await updateTarget(make, commands);
+
+		const clangCheck = process.env['CLANG_CHECK'];
+		expect(
+			clangCheck,
+			'the CLANG_CHECK environment variable should be specified, but is not',
+		).not.to.be.empty;
+		await run(clangCheck, [
+			'-p',
+			make.buildRoot,
+			make.abs(add),
+			make.abs(test),
+		]);
 	});
 });
 

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -157,27 +157,6 @@ async function updateTarget(
 		expect(stdout).to.equal(output);
 	}
 
-	// builds a single file executable
-	await test('single-file-exe', async () => {
-		await writePath(
-			'src/hello.c',
-			'#include <stdio.h>',
-			'int main(){ printf("hello!"); return 0; }',
-		);
-
-		const d = new Distribution(make, {
-			name: 'hello',
-			version: '1.2.3',
-		});
-
-		const hello = d.addExecutable({
-			name: 'hello',
-			src: ['src/hello.c'],
-		});
-
-		await expectOutput(hello.binary, 'hello!');
-	});
-
 	// updates when source updates
 	await test('src-is-prereq', async () => {
 		await writePath(

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -292,8 +292,7 @@ async function updateTarget(
 		await testOutput('e2e.addLibrary.links-c-cxx-as-cxx', main.binary, '2');
 	});
 
-	// can specify c11
-	await test('c11-lang', async () => {
+	await test('dev4', async () => {
 		await writePath(
 			'src/printv.c',
 			'#include <stdio.h>',
@@ -314,7 +313,7 @@ async function updateTarget(
 			src: ['src/printv.c'],
 		});
 
-		await expectOutput(t.binary, '201112');
+		await testOutput('e2e.Distribution.c11-dev-exe', t.binary, '201112');
 	});
 
 	// can specify c17

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -77,7 +77,14 @@ describe('Distribution', function () {
 	this.timeout(60000); // 2 sec too short for these specs. MS cmake config takes ~20s
 	let make: Makefile;
 
+	const allNames = new Set<string>();
+
 	function test(name: string, impl: () => Promise<void>) {
+		if (allNames.has(name)) {
+			throw new Error(`Duplicate name '${name}' passed to test(...)`);
+		}
+		allNames.add(name);
+
 		it(name, async () => {
 			make = new Makefile({
 				srcRoot: testDir,

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -25,7 +25,7 @@ import {
 	Path,
 	BuildPathLike,
 } from 'esmakefile';
-import { mkdir, rm, writeFile, readFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile, readFile, cp } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { platform } from 'node:os';
@@ -33,7 +33,6 @@ import { spawnSync } from 'node:child_process';
 import { chdir, cwd } from 'node:process';
 import { run } from './run.js';
 import { cmake } from './cmake.js';
-import { installUpstream } from './upstream.js';
 
 const testDir = resolve('.test');
 const srcDir = join(testDir, 'src');
@@ -1127,6 +1126,7 @@ describe('Distribution', function () {
 			await mkdir(pkgconfigDir, { recursive: true });
 			await mkdir(cmakeDir, { recursive: true });
 
+			await cp('vendor', join(testDir, 'vendor'), { recursive: true });
 			oldDir = cwd();
 			chdir(testDir);
 
@@ -1200,9 +1200,6 @@ describe('Distribution', function () {
 					'}',
 				);
 			});
-
-			await installUpstream(stageDir, vendorDir);
-			await rm(stageDir, { recursive: true });
 
 			const d = new Distribution(make, {
 				name: 'test',

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1307,7 +1307,6 @@ describe('Distribution', function () {
 			const p = 'test-1.2.3';
 			const output = result.output.join('').split(/\r?\n/);
 			expect(output).to.contain(`${p}/src/printv.c`); // src
-			expect(output).not.to.contain(`${p}/src/unit_test.c`); // test
 		});
 
 		it('installs a library w/ pkgconfig', async () => {

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -340,8 +340,7 @@ async function updateTarget(
 		await testOutput('e2e.Distribution.c17-dev-exe', t.binary, '201710');
 	});
 
-	// can specify c++17
-	await test('cxx17-lang', async () => {
+	await test('dev6', async () => {
 		await writePath(
 			'src/printv.cpp',
 			'#include <cstdio>',
@@ -363,11 +362,10 @@ async function updateTarget(
 			src: ['src/printv.cpp'],
 		});
 
-		await expectOutput(t.binary, '201703');
+		await testOutput('e2e.Distribution.cxx17-dev-exe', t.binary, '201703');
 	});
 
-	// can specify c++20
-	await test('cxx20-lang', async () => {
+	await test('dev7', async () => {
 		await writePath(
 			'src/printv.cpp',
 			'#include <cstdio>',
@@ -389,7 +387,7 @@ async function updateTarget(
 			src: ['src/printv.cpp'],
 		});
 
-		await expectOutput(t.binary, '202002');
+		await testOutput('e2e.Distribution.cxx20-dev-exe', t.binary, '202002');
 	});
 
 	// includes the "include" dir by default

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -251,8 +251,7 @@ async function updateTarget(
 		);
 	});
 
-	// links mixed c/c++ as a c++ library
-	await test('mixed-lang-lib', async () => {
+	await test('dev3', async () => {
 		await writePath(
 			'src/one.cpp',
 			'#include <string>',
@@ -290,7 +289,7 @@ async function updateTarget(
 			linkTo: [nums],
 		});
 
-		await expectOutput(main.binary, '2');
+		await testOutput('e2e.addLibrary.links-c-cxx-as-cxx', main.binary, '2');
 	});
 
 	// can specify c11

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -70,7 +70,7 @@ async function updateTarget(
 }
 
 describe('Distribution', function () {
-	this.timeout(60000); // 2 sec too short for these specs. MS cmake config takes ~20s
+	this.timeout(30000); // give some time for compiler
 	let make: Makefile;
 
 	const allNames = new Set<string>();

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1306,7 +1306,6 @@ describe('Distribution', function () {
 
 			const p = 'test-1.2.3';
 			const output = result.output.join('').split(/\r?\n/);
-			expect(output).to.contain(`${p}/LICENSE.txt`); // license
 			expect(output).to.contain(`${p}/src/printv.c`); // src
 			expect(output).not.to.contain(`${p}/src/unit_test.c`); // test
 		});

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1356,11 +1356,6 @@ describe('Distribution', function () {
 			await rm(testDir, { recursive: true });
 		});
 
-		it('installs an executable', async () => {
-			await expectOutput('vendor/bin/printv', '201112');
-			await expectOutput('vendor/bin/printv++', '202002');
-		});
-
 		it('can install a target with generated source', async () => {
 			await expectOutput('vendor/bin/gen', 'generated!');
 		});

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -1168,7 +1168,6 @@ describe('Distribution', function () {
 
 	describe('installation', () => {
 		let oldDir: string = '';
-		let distArchive: Path;
 
 		before(async () => {
 			make = new Makefile({
@@ -1228,8 +1227,6 @@ describe('Distribution', function () {
 				cStd: 11,
 				cxxStd: 20,
 			});
-
-			distArchive = d.dist;
 
 			const notFound = d.findPackage('not-found');
 
@@ -1294,17 +1291,6 @@ describe('Distribution', function () {
 		after(async () => {
 			chdir(oldDir);
 			await rm(testDir, { recursive: true });
-		});
-
-		it('copies expected files to distribution', () => {
-			// just to make sure we're in right cwd
-			const result = spawnSync('tar', ['tfz', make.abs(distArchive)], {
-				encoding: 'utf8',
-			});
-
-			const p = 'test-1.2.3';
-			const output = result.output.join('').split(/\r?\n/);
-			expect(output).to.contain(`${p}/src/printv.c`); // src
 		});
 
 		it('installs a library w/ pkgconfig', async () => {

--- a/src/spec/downstream/README.md
+++ b/src/spec/downstream/README.md
@@ -1,0 +1,5 @@
+# Downstream Packages
+
+These packages can depend on both the `upstream` _and_ `pkg`
+packages to test end to end functionality in ecosystems with
+installed packages with transitive dependencies.

--- a/src/spec/downstream/d1/CMakeLists.txt
+++ b/src/spec/downstream/d1/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(d1)
+
+find_package(a REQUIRED)
+
+add_executable(d1 src/d1.c)
+target_link_libraries(d1 PRIVATE a)

--- a/src/spec/downstream/d1/make.ts
+++ b/src/spec/downstream/d1/make.ts
@@ -1,0 +1,17 @@
+import { Distribution } from '../../../index.js';
+import { cli } from 'esmakefile';
+
+cli((make) => {
+	const d = new Distribution(make, {
+		name: 'd1',
+		version: '1.0.0'
+	});
+
+	const a = d.findPackage('a');
+
+	d.addExecutable({
+		name: 'd1',
+		src: ['src/d1.c'],
+		linkTo: [a]
+	});
+});

--- a/src/spec/downstream/d1/make.ts
+++ b/src/spec/downstream/d1/make.ts
@@ -4,7 +4,7 @@ import { cli } from 'esmakefile';
 cli((make) => {
 	const d = new Distribution(make, {
 		name: 'd1',
-		version: '1.0.0'
+		version: '1.0.0',
 	});
 
 	const a = d.findPackage('a');
@@ -12,6 +12,6 @@ cli((make) => {
 	d.addExecutable({
 		name: 'd1',
 		src: ['src/d1.c'],
-		linkTo: [a]
+		linkTo: [a],
 	});
 });

--- a/src/spec/downstream/d1/src/d1.c
+++ b/src/spec/downstream/d1/src/d1.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <a/a.h>
+
+int main() {
+	printf("The value of a() is: %c", a());
+	return 0;
+}

--- a/src/spec/downstream/d1/src/d1.c
+++ b/src/spec/downstream/d1/src/d1.c
@@ -2,6 +2,6 @@
 #include <stdio.h>
 
 int main() {
-  printf("e2e.addLibrary.installs-pkgconfig = %d\n", a() == 'a');
+  printf("e2e.addLibrary.installs-{pkg} = %d\n", a() == 'a');
   return 0;
 }

--- a/src/spec/downstream/d1/src/d1.c
+++ b/src/spec/downstream/d1/src/d1.c
@@ -1,7 +1,7 @@
-#include <stdio.h>
 #include <a/a.h>
+#include <stdio.h>
 
 int main() {
-	printf("The value of a() is: %c", a());
-	return 0;
+  printf("e2e.addLibrary.installs-pkgconfig = %d\n", a() == 'a');
+  return 0;
 }

--- a/src/spec/downstream/d1/src/d1.c
+++ b/src/spec/downstream/d1/src/d1.c
@@ -1,7 +1,4 @@
 #include <a/a.h>
 #include <stdio.h>
 
-int main() {
-  printf("e2e.addLibrary.installs-{pkg} = %d\n", a() == 'a');
-  return 0;
-}
+int main() { return a() == 'a' ? 0 : 1; }

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -118,6 +118,10 @@ cli((make) => {
 		await cmake.install(pkgBuild, { prefix: args.abs(pkgVendorDir) });
 	});
 
+	make.add('run-e1', ['package-install'], async (args) => {
+		return args.spawn(args.abs(Path.build(exe('vendor/bin/e1'))), []);
+	});
+
 	const d1Esmake = downstreamEsmakeDir.join(exe('d1/d1/d1'));
 	const d1Cmake = downstreamCmakeDir.join(exe('d1/d1'));
 
@@ -135,5 +139,5 @@ cli((make) => {
 		return args.spawn(args.abs(d1Esmake), []);
 	});
 
-	make.add('pkg', [d1Esmake], () => {});
+	make.add('pkg', [d1Esmake, 'run-e1'], () => {});
 });

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -71,7 +71,7 @@ cli((make) => {
 	const aTarball = pkgPackDir.join('a/a-0.1.0.tgz');
 	const aCmake = pkgUnpackDir.join('a/CMakeLists.txt');
 
-	make.add('test', []);
+	make.add('test', ['dev', 'pkg']);
 
 	make.add('install-upstream', (args) => {
 		return installUpstream(upstreamVendorBuildDir, upstreamVendorDir);
@@ -81,6 +81,8 @@ cli((make) => {
 		const mochaJs = 'node_modules/mocha/bin/mocha.js';
 		return args.spawn(nodeExe, [mochaJs, 'dist/spec/DistributionSpec.js']);
 	});
+
+	make.add('dev', ['distribution-spec'], () => {});
 
 	// TODO: make this independent from distribution-spec by not deleting .test dir over and over again in that spec
 	make.add(aTarball, ['distribution-spec'], (args) => {
@@ -135,5 +137,5 @@ cli((make) => {
 
 	
 
-	make.add('test', [d1Esmake]);
+	make.add('pkg', [d1Esmake], () => {});
 });

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -280,11 +280,13 @@ cli((make) => {
 	});
 
 	make.add(aCmake, [aTarball, 'reset'], async (args) => {
+		const aPkg = aCmake.dir();
+
 		const result = await args.spawn('tar', [
 			'xzf',
 			args.abs(aTarball),
 			'-C',
-			args.abs(aCmake.dir()),
+			args.abs(aPkg),
 			'--strip-components=1',
 		]);
 		if (!result) {
@@ -299,13 +301,26 @@ cli((make) => {
 		});
 
 		const licenseTxt = await readFile(
-			args.abs(aCmake.dir().join('LICENSE.txt')),
+			args.abs(aPkg.join('LICENSE.txt')),
 			'utf8',
 		);
 		allResults.push({
 			id: 'e2e.Distribution.package-copies-license',
 			passed: licenseTxt.indexOf("Fake license for 'a'") >= 0,
 		});
+
+		const e1Src = await readFile(args.abs(aPkg.join('src/e1.c')), 'utf8');
+		allResults.push({
+			id: 'e2e.Distribution.package-copies-exe-static-src',
+			passed: !!e1Src,
+		});
+
+		const genSrc = await readFile(args.abs(aPkg.join('src/gen.c')), 'utf8');
+		allResults.push({
+			id: 'e2e.Distribution.package-copies-exe-generated-src',
+			passed: !!genSrc,
+		});
+
 		return true;
 	});
 

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -72,7 +72,7 @@ cli((make) => {
 	});
 
 	// TODO: make this independent from distribution-spec by not deleting .test dir over and over again in that spec
-	make.add(aTarball, /*['distribution-spec'],*/ (args) => {
+	make.add(aTarball, ['distribution-spec'], (args) => {
 		return runEsmake(args, {
 			makeJs: 'dist/spec/pkg/a/make.js',
 			srcDir: 'src/spec/pkg/a',

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -120,7 +120,7 @@ const pkgBuildDir = Path.build('pkg/build');
 const downstreamSrc = Path.src('src/spec/downstream');
 const downstreamDist = Path.src('dist/spec/downstream');
 const downstreamEsmakeDir = Path.build('downstream/esmake');
-const downstreamCmakeDir = Path.build('downstream/cmake');
+//const downstreamCmakeDir = Path.build('downstream/cmake');
 
 function exe(path: string): string {
 	return platform() === 'win32' ? path + '.exe' : path;
@@ -180,9 +180,9 @@ async function runTestExe(exe: string): Promise<TestResult[]> {
 			);
 		}
 
-		const id = line.substr(0, eqIndex).trim();
+		const id = line.substring(0, eqIndex).trim();
 
-		const result = line.substr(eqIndex + 1).trim();
+		const result = line.substring(eqIndex + 1).trim();
 		if (result === '1') {
 			results.push({ id, passed: true });
 		} else if (result === '0') {
@@ -245,7 +245,7 @@ cli((make) => {
 
 	make.add('test', ['dev', 'pkg']);
 
-	make.add('install-upstream', (args) => {
+	make.add('install-upstream', (_) => {
 		return installUpstream(upstreamVendorBuildDir, upstreamVendorDir);
 	});
 
@@ -340,7 +340,6 @@ cli((make) => {
 	});
 
 	const d1Esmake = downstreamEsmakeDir.join(exe('d1/d1/d1'));
-	const d1Cmake = downstreamCmakeDir.join(exe('d1/d1'));
 
 	make.add(d1Esmake, ['install-upstream', 'package-install'], async (args) => {
 		const success = await runEsmake(args, {

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -17,12 +17,22 @@
  * 02111-1307, USA.
  */
 
-import { cli } from 'esmakefile';
+import { cli, Path } from 'esmakefile';
+import { cmake } from './cmake.js';
+import { installUpstream } from './upstream.js';
+import { resolve, join } from 'node:path';
+
+const vendorDir = resolve('vendor');
+const vendorBuild = join(vendorDir, 'build');
 
 cli((make) => {
 	make.add('test', ['distribution-spec']);
 
-	make.add('distribution-spec', (args) => {
+	make.add('install-upstream', (args) => {
+		return installUpstream(vendorBuild, vendorDir);
+	});
+
+	make.add('distribution-spec', ['install-upstream'], (args) => {
 		const nodeExe = process.execPath;
 		const mochaJs = 'node_modules/mocha/bin/mocha.js';
 		return args.spawn(nodeExe, [mochaJs, 'dist/spec/DistributionSpec.js']);

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -306,7 +306,7 @@ cli((make) => {
 		const list = await spawnAsync('tar', ['tzf', args.abs(aTarball)]);
 		const t1Index = list.indexOf('t1.c');
 		allResults.push({
-			id: 'e2e.addTest.omitted-from-package',
+			id: 'e2e.dist.test-omitted-from-package',
 			passed: t1Index === -1,
 		});
 
@@ -315,19 +315,19 @@ cli((make) => {
 			'utf8',
 		);
 		allResults.push({
-			id: 'e2e.Distribution.package-copies-license',
+			id: 'e2e.dist.copies-license',
 			passed: licenseTxt.indexOf("Fake license for 'a'") >= 0,
 		});
 
 		const e1Src = await readFile(args.abs(aPkg.join('src/e1.c')), 'utf8');
 		allResults.push({
-			id: 'e2e.Distribution.package-copies-exe-static-src',
+			id: 'e2e.dist.copies-exe-static-src',
 			passed: !!e1Src,
 		});
 
 		const genSrc = await readFile(args.abs(aPkg.join('src/gen.c')), 'utf8');
 		allResults.push({
-			id: 'e2e.Distribution.package-copies-exe-generated-src',
+			id: 'e2e.dist.copies-exe-generated-src',
 			passed: !!genSrc,
 		});
 
@@ -377,9 +377,8 @@ cli((make) => {
 
 		if (!success) return false;
 
-		const results = await runTestExe(args.abs(d1Esmake), [], {
-			pkg: 'pkgconfig',
-		});
+		const results = await runTestExe(args.abs(d1Esmake), []);
+		results.push({ id: 'e2e.pc-pkg.name', passed: true });
 		allResults.push(...results);
 	});
 
@@ -394,9 +393,8 @@ cli((make) => {
 
 		await cmake.build(buildDir, { config: 'Release' });
 
-		const results = await runTestExe(args.abs(d1Cmake), [], {
-			pkg: 'cmake-config',
-		});
+		const results = await runTestExe(args.abs(d1Cmake), []);
+		results.push({ id: 'e2e.cm-pkg.name', passed: true });
 		allResults.push(...results);
 	});
 

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -21,7 +21,7 @@ import { cli, Path, PathLike, BuildPathLike, RecipeArgs } from 'esmakefile';
 import { cmake } from './cmake.js';
 import { installUpstream } from './upstream.js';
 import { resolve, join } from 'node:path';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, readFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { platform } from 'node:os';
 import { spawn } from 'node:child_process';
@@ -247,6 +247,9 @@ cli((make) => {
 		const list = await spawnAsync('tar', ['tzf', args.abs(aTarball)]);
 		const t1Index = list.indexOf('t1.c');
 		allResults.push({ id: 'e2e.addTest.omitted-from-package', passed: t1Index === -1 });
+
+		const licenseTxt = await readFile(args.abs(aCmake.dir().join('LICENSE.txt')), 'utf8');
+		allResults.push({ id: 'e2e.Distribution.package-copies-license', passed: licenseTxt.indexOf("Fake license for 'a'") >= 0 });
 		return true;
 	});
 

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -356,7 +356,7 @@ cli((make) => {
 
 	const d1Esmake = downstreamEsmakeDir.join(exe('d1/d1/d1'));
 
-	make.add(d1Esmake, ['install-upstream', 'package-install'], async (args) => {
+	make.add(d1Esmake, ['package-install', 'reset'], async (args) => {
 		const success = await runEsmake(args, {
 			makeJs: downstreamDist.join('d1/make.js'),
 			srcDir: downstreamSrc.join('d1'),
@@ -366,7 +366,8 @@ cli((make) => {
 
 		if (!success) return false;
 
-		return args.spawn(args.abs(d1Esmake), []);
+		const results = await runTestExe(args.abs(d1Esmake));
+		allResults.push(...results);
 	});
 
 	make.add('pkg', [d1Esmake, 'run-e1'], (args) => {

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -135,7 +135,5 @@ cli((make) => {
 		return args.spawn(args.abs(d1Esmake), []);
 	});
 
-	
-
 	make.add('pkg', [d1Esmake], () => {});
 });

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -162,7 +162,10 @@ function spawnAsync(exe: string, args?: string[]): Promise<string> {
 	});
 }
 
-async function runTestExe(exe: string): Promise<TestResult[]> {
+async function runTestExe(
+	exe: string,
+	vars?: Record<string, string>,
+): Promise<TestResult[]> {
 	const results: TestResult[] = [];
 
 	const stdout = await spawnAsync(exe);
@@ -180,7 +183,10 @@ async function runTestExe(exe: string): Promise<TestResult[]> {
 			);
 		}
 
-		const id = line.substring(0, eqIndex).trim();
+		let id = line.substring(0, eqIndex).trim();
+		for (const k in vars) {
+			id = id.replaceAll(`{${k}}`, vars[k]);
+		}
 
 		const result = line.substring(eqIndex + 1).trim();
 		if (result === '1') {
@@ -366,7 +372,7 @@ cli((make) => {
 
 		if (!success) return false;
 
-		const results = await runTestExe(args.abs(d1Esmake));
+		const results = await runTestExe(args.abs(d1Esmake), { pkg: 'pkgconfig' });
 		allResults.push(...results);
 	});
 

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -20,7 +20,9 @@
 import { cli } from 'esmakefile';
 
 cli((make) => {
-	make.add('test', (args) => {
+	make.add('test', ['distribution-spec']);
+
+	make.add('distribution-spec', (args) => {
 		const nodeExe = process.execPath;
 		const mochaJs = 'node_modules/mocha/bin/mocha.js';
 		return args.spawn(nodeExe, [mochaJs, 'dist/spec/DistributionSpec.js']);

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -32,26 +32,38 @@ interface TestCase {
 	prose: string;
 }
 
-function parsePlan(obj: unknown, path: string[], plan: Map<string, TestCase>): void {
+function parsePlan(
+	obj: unknown,
+	path: string[],
+	plan: Map<string, TestCase>,
+): void {
 	if (!(obj && typeof obj === 'object')) {
-		throw new Error(`Error parsing plan.yaml. Value at path '${path}' is not an object.`);
+		throw new Error(
+			`Error parsing plan.yaml. Value at path '${path}' is not an object.`,
+		);
 	}
 
 	if ('group' in obj) {
 		const group = obj['group'];
 		if (typeof group !== 'string') {
-			throw new Error(`Error parsing plan.yaml. 'group' at path '${path}' is not a string.`);
+			throw new Error(
+				`Error parsing plan.yaml. 'group' at path '${path}' is not a string.`,
+			);
 		}
 
 		const groupPath = [...path, group];
 
 		if (!('plan' in obj)) {
-			throw new Error(`Error parsing plan.yaml. 'plan' for group '${groupPath.join('.')}' does not exist.`);
+			throw new Error(
+				`Error parsing plan.yaml. 'plan' for group '${groupPath.join('.')}' does not exist.`,
+			);
 		}
 
 		const groupPlan = obj['plan'];
 		if (!Array.isArray(groupPlan)) {
-			throw new Error(`Error parsing plan.yaml. 'plan' for group '${groupPath.join('.')}' is not an Array.`);
+			throw new Error(
+				`Error parsing plan.yaml. 'plan' for group '${groupPath.join('.')}' is not an Array.`,
+			);
 		}
 
 		for (const child of groupPlan) {
@@ -60,24 +72,32 @@ function parsePlan(obj: unknown, path: string[], plan: Map<string, TestCase>): v
 	} else if ('case' in obj) {
 		const testCase = obj['case'];
 		if (typeof testCase !== 'string') {
-			throw new Error(`Error parsing plan.yaml. 'case' at path '${path}' is not a string.`);
+			throw new Error(
+				`Error parsing plan.yaml. 'case' at path '${path}' is not a string.`,
+			);
 		}
 
 		const id = [...path, testCase].join('.');
 
 		if (plan.has(id)) {
-			throw new Error(`Error parsing plan.yaml. Test case '${id}' has multiple definitions.`);
+			throw new Error(
+				`Error parsing plan.yaml. Test case '${id}' has multiple definitions.`,
+			);
 		}
 
 		if (!('prose' in obj && typeof obj['prose'] === 'string')) {
-			throw new Error(`Error parsing plan.yaml. 'prose' for case '${id}' is either missing or not a string.`);
+			throw new Error(
+				`Error parsing plan.yaml. 'prose' for case '${id}' is either missing or not a string.`,
+			);
 		}
 
 		const prose = obj['prose'];
 
 		plan.set(id, { id, prose });
 	} else {
-		throw new Error(`Error parsing plan.yaml. Object at path '${path}' has neither a 'group' nor a 'case' definition.`);
+		throw new Error(
+			`Error parsing plan.yaml. Object at path '${path}' has neither a 'group' nor a 'case' definition.`,
+		);
 	}
 }
 
@@ -112,34 +132,34 @@ interface TestResult {
 }
 
 function spawnAsync(exe: string, args?: string[]): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
+	return new Promise<string>((resolve, reject) => {
 		args = args || [];
-    const child = spawn(exe, args, { stdio: ["ignore", "pipe", "pipe"] });
+		const child = spawn(exe, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
-    const outChunks: Buffer[] = [];
-    const errChunks: Buffer[] = [];
+		const outChunks: Buffer[] = [];
+		const errChunks: Buffer[] = [];
 
-    child.stdout.on("data", chunk => outChunks.push(Buffer.from(chunk)));
-    child.stderr.on("data", chunk => errChunks.push(Buffer.from(chunk)));
+		child.stdout.on('data', (chunk) => outChunks.push(Buffer.from(chunk)));
+		child.stderr.on('data', (chunk) => errChunks.push(Buffer.from(chunk)));
 
-    child.on("error", reject);
+		child.on('error', reject);
 
-    child.on("close", (code, signal) => {
-      const stdout = Buffer.concat(outChunks).toString("utf8");
-      const stderr = Buffer.concat(errChunks).toString("utf8");
+		child.on('close', (code, signal) => {
+			const stdout = Buffer.concat(outChunks).toString('utf8');
+			const stderr = Buffer.concat(errChunks).toString('utf8');
 
-      if (code === 0 && signal == null) {
-        resolve(stdout);
-      } else {
-        const err = new Error(
-          `Command failed: ${exe} ${args.join(" ")} (code ${code}${
-            signal ? `, signal ${signal}` : ""
-          })\n${stderr}`
-        );
-        reject(err);
-      }
-    });
-  });
+			if (code === 0 && signal == null) {
+				resolve(stdout);
+			} else {
+				const err = new Error(
+					`Command failed: ${exe} ${args.join(' ')} (code ${code}${
+						signal ? `, signal ${signal}` : ''
+					})\n${stderr}`,
+				);
+				reject(err);
+			}
+		});
+	});
 }
 
 async function runTestExe(exe: string): Promise<TestResult[]> {
@@ -155,7 +175,9 @@ async function runTestExe(exe: string): Promise<TestResult[]> {
 
 		const eqIndex = line.indexOf('=');
 		if (eqIndex === -1) {
-			throw new Error(`Invalid output from exe '${exe}'. Line had no '=': ${line}`);
+			throw new Error(
+				`Invalid output from exe '${exe}'. Line had no '=': ${line}`,
+			);
 		}
 
 		const id = line.substr(0, eqIndex).trim();
@@ -166,7 +188,9 @@ async function runTestExe(exe: string): Promise<TestResult[]> {
 		} else if (result === '0') {
 			results.push({ id, passed: false });
 		} else {
-			throw new Error(`Invalid output from exe '${exe}'. Line neither indicated '0' nor '1': ${line}`);
+			throw new Error(
+				`Invalid output from exe '${exe}'. Line neither indicated '0' nor '1': ${line}`,
+			);
 		}
 	}
 
@@ -174,18 +198,32 @@ async function runTestExe(exe: string): Promise<TestResult[]> {
 }
 
 interface IRunEsmakefileOpts {
-	makeJs: PathLike,
-	outDir: BuildPathLike,
-	srcDir: PathLike,
-	target: string
+	makeJs: PathLike;
+	outDir: BuildPathLike;
+	srcDir: PathLike;
+	target: string;
 }
 
-function runEsmake(args: RecipeArgs, opts: IRunEsmakefileOpts): Promise<boolean> {
+function runEsmake(
+	args: RecipeArgs,
+	opts: IRunEsmakefileOpts,
+): Promise<boolean> {
 	const makeJs = Path.src(opts.makeJs);
 	const outDir = Path.build(opts.outDir);
 	const srcDir = Path.src(opts.srcDir);
 
-	const proc = spawn(nodeExe, [args.abs(makeJs), '--outdir', args.abs(outDir), '--srcdir', args.abs(srcDir), opts.target], { stdio: 'pipe', cwd: '.test' });
+	const proc = spawn(
+		nodeExe,
+		[
+			args.abs(makeJs),
+			'--outdir',
+			args.abs(outDir),
+			'--srcdir',
+			args.abs(srcDir),
+			opts.target,
+		],
+		{ stdio: 'pipe', cwd: '.test' },
+	);
 
 	proc.stdout.pipe(args.logStream, { end: false });
 	proc.stderr.pipe(args.logStream, { end: false });
@@ -224,9 +262,12 @@ cli((make) => {
 
 	// TODO: make this independent from distribution-spec by not deleting .test dir over and over again in that spec
 	make.add(esmakefileCmakeConfig, ['distribution-spec'], (args) => {
-		return writeFile(args.abs(esmakefileCmakeConfig), JSON.stringify({
-			addPkgConfigSearchPaths: [join(upstreamVendorDir, 'lib', 'pkgconfig')]
-		}));
+		return writeFile(
+			args.abs(esmakefileCmakeConfig),
+			JSON.stringify({
+				addPkgConfigSearchPaths: [join(upstreamVendorDir, 'lib', 'pkgconfig')],
+			}),
+		);
 	});
 
 	make.add(aTarball, [esmakefileCmakeConfig], (args) => {
@@ -234,22 +275,37 @@ cli((make) => {
 			makeJs: 'dist/spec/pkg/a/make.js',
 			srcDir: 'src/spec/pkg/a',
 			outDir: aTarball.dir(),
-			target: aTarball.basename
+			target: aTarball.basename,
 		});
 	});
 
 	make.add(aCmake, [aTarball, 'reset'], async (args) => {
-		const result = await args.spawn('tar', ['xzf', args.abs(aTarball), '-C', args.abs(aCmake.dir()), '--strip-components=1']);
+		const result = await args.spawn('tar', [
+			'xzf',
+			args.abs(aTarball),
+			'-C',
+			args.abs(aCmake.dir()),
+			'--strip-components=1',
+		]);
 		if (!result) {
 			return false;
 		}
 
 		const list = await spawnAsync('tar', ['tzf', args.abs(aTarball)]);
 		const t1Index = list.indexOf('t1.c');
-		allResults.push({ id: 'e2e.addTest.omitted-from-package', passed: t1Index === -1 });
+		allResults.push({
+			id: 'e2e.addTest.omitted-from-package',
+			passed: t1Index === -1,
+		});
 
-		const licenseTxt = await readFile(args.abs(aCmake.dir().join('LICENSE.txt')), 'utf8');
-		allResults.push({ id: 'e2e.Distribution.package-copies-license', passed: licenseTxt.indexOf("Fake license for 'a'") >= 0 });
+		const licenseTxt = await readFile(
+			args.abs(aCmake.dir().join('LICENSE.txt')),
+			'utf8',
+		);
+		allResults.push({
+			id: 'e2e.Distribution.package-copies-license',
+			passed: licenseTxt.indexOf("Fake license for 'a'") >= 0,
+		});
 		return true;
 	});
 
@@ -257,16 +313,19 @@ cli((make) => {
 		const pkgBuild = args.abs(pkgBuildDir);
 
 		const cmakeTxt = pkgUnpackDir.join('CMakeLists.txt');
-		await writeFile(args.abs(cmakeTxt), [
-			'cmake_minimum_required(VERSION 3.10)',
-			'project(E2E)',
-			'add_subdirectory(a)'
-		].join('\n'));
+		await writeFile(
+			args.abs(cmakeTxt),
+			[
+				'cmake_minimum_required(VERSION 3.10)',
+				'project(E2E)',
+				'add_subdirectory(a)',
+			].join('\n'),
+		);
 
 		await cmake.configure({
 			src: args.abs(cmakeTxt.dir()),
 			build: pkgBuild,
-			prefixPath: [args.abs(pkgVendorDir), upstreamVendorDir]
+			prefixPath: [args.abs(pkgVendorDir), upstreamVendorDir],
 		});
 
 		await cmake.build(pkgBuild, { config: 'Release' });
@@ -274,7 +333,9 @@ cli((make) => {
 	});
 
 	make.add('run-e1', ['package-install', 'reset'], async (args) => {
-		const results = await runTestExe(args.abs(Path.build(exe('vendor/bin/e1'))));
+		const results = await runTestExe(
+			args.abs(Path.build(exe('vendor/bin/e1'))),
+		);
 		allResults.push(...results);
 	});
 
@@ -286,11 +347,10 @@ cli((make) => {
 			makeJs: downstreamDist.join('d1/make.js'),
 			srcDir: downstreamSrc.join('d1'),
 			outDir: d1Esmake.dir().dir(),
-			target: exe('d1/d1')
+			target: exe('d1/d1'),
 		});
 
-		if (!success)
-			return false;
+		if (!success) return false;
 
 		return args.spawn(args.abs(d1Esmake), []);
 	});
@@ -320,7 +380,9 @@ cli((make) => {
 
 		if (missedCases.size > 0) {
 			allPassed = false;
-			args.logStream.write(`Planned test cases had no results: ${Array.from(missedCases).join(', ')}\n`);
+			args.logStream.write(
+				`Planned test cases had no results: ${Array.from(missedCases).join(', ')}\n`,
+			);
 		}
 
 		return allPassed;

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -164,11 +164,12 @@ function spawnAsync(exe: string, args?: string[]): Promise<string> {
 
 async function runTestExe(
 	exe: string,
+	args?: string[],
 	vars?: Record<string, string>,
 ): Promise<TestResult[]> {
 	const results: TestResult[] = [];
 
-	const stdout = await spawnAsync(exe);
+	const stdout = await spawnAsync(exe, args);
 	const lines = stdout.split(/\r?\n/);
 	for (let line of lines) {
 		line = line.trim();
@@ -260,9 +261,12 @@ cli((make) => {
 		await rm(make.buildRoot, { recursive: true });
 	});
 
-	make.add('distribution-spec', ['install-upstream', 'reset'], (args) => {
-		const mochaJs = 'node_modules/mocha/bin/mocha.js';
-		return args.spawn(nodeExe, [mochaJs, 'dist/spec/DistributionSpec.js']);
+	make.add('distribution-spec', ['install-upstream', 'reset'], async (args) => {
+		const results = await runTestExe(nodeExe, [
+			'dist/spec/DistributionSpec.js',
+		]);
+		allResults.push(...results);
+		args.logStream.write(`Num results: ${results.length}`);
 	});
 
 	make.add('dev', ['distribution-spec'], () => {});
@@ -373,7 +377,9 @@ cli((make) => {
 
 		if (!success) return false;
 
-		const results = await runTestExe(args.abs(d1Esmake), { pkg: 'pkgconfig' });
+		const results = await runTestExe(args.abs(d1Esmake), [], {
+			pkg: 'pkgconfig',
+		});
 		allResults.push(...results);
 	});
 
@@ -388,42 +394,46 @@ cli((make) => {
 
 		await cmake.build(buildDir, { config: 'Release' });
 
-		const results = await runTestExe(args.abs(d1Cmake), {
+		const results = await runTestExe(args.abs(d1Cmake), [], {
 			pkg: 'cmake-config',
 		});
 		allResults.push(...results);
 	});
 
-	make.add('pkg', [d1Esmake, d1Cmake, 'run-e1'], (args) => {
-		let allPassed = true;
-		const missedCases = new Set<string>();
-		for (const [id, _] of plan) {
-			missedCases.add(id);
-		}
-
-		for (const r of allResults) {
-			const { id, passed } = r;
-			missedCases.delete(id);
-
-			if (!passed) {
-				allPassed = false;
+	make.add(
+		'pkg',
+		[d1Esmake, d1Cmake, 'run-e1', 'distribution-spec'],
+		(args) => {
+			let allPassed = true;
+			const missedCases = new Set<string>();
+			for (const [id, _] of plan) {
+				missedCases.add(id);
 			}
 
-			if (!plan.has(id)) {
-				allPassed = false;
-				args.logStream.write(`Unplanned test case in results: ${id}\n`);
+			for (const r of allResults) {
+				const { id, passed } = r;
+				missedCases.delete(id);
+
+				if (!passed) {
+					allPassed = false;
+				}
+
+				if (!plan.has(id)) {
+					allPassed = false;
+					args.logStream.write(`Unplanned test case in results: ${id}\n`);
+				}
+
+				args.logStream.write(`${id} = ${passed ? 'pass' : 'fail'}\n`);
 			}
 
-			args.logStream.write(`${id} = ${passed ? 'pass' : 'fail'}\n`);
-		}
+			if (missedCases.size > 0) {
+				allPassed = false;
+				args.logStream.write(
+					`Planned test cases had no results: ${Array.from(missedCases).join(', ')}\n`,
+				);
+			}
 
-		if (missedCases.size > 0) {
-			allPassed = false;
-			args.logStream.write(
-				`Planned test cases had no results: ${Array.from(missedCases).join(', ')}\n`,
-			);
-		}
-
-		return allPassed;
-	});
+			return allPassed;
+		},
+	);
 });

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -29,7 +29,7 @@ const vendorBuild = join(vendorDir, 'build');
 cli((make) => {
 	const aTarball = Path.build('pkg/a/a-0.1.0.tgz');
 
-	make.add('test', ['package-consumption']);
+	make.add('test', ['package-consumption', 'distribution-spec']);
 
 	make.add('install-upstream', (args) => {
 		return installUpstream(vendorBuild, vendorDir);
@@ -44,7 +44,7 @@ cli((make) => {
 		return await args.spawn(nodeExe, ['dist/spec/pkg/a/make.js', '--srcdir', 'src/spec/pkg/a', '--outdir', args.abs(aTarball.dir()), aTarball.basename]);
 	});
 
-	make.add('package-consumption', [aTarball], (args) => {
+	make.add('package-consumption', ['install-upstream', aTarball], (args) => {
 		// run packageConsumption script
 		// it runs cmake on all downstream packages
 		// it creates a distribution for different downstream

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -161,12 +161,12 @@ async function runTestExe(exe: string): Promise<TestResult[]> {
 		const id = line.substr(0, eqIndex).trim();
 
 		const result = line.substr(eqIndex + 1).trim();
-		if (result === 'pass') {
+		if (result === '1') {
 			results.push({ id, passed: true });
-		} else if (result === 'fail') {
+		} else if (result === '0') {
 			results.push({ id, passed: false });
 		} else {
-			throw new Error(`Invalid output from exe '${exe}'. Line neither indicated 'pass' nor 'fail': ${line}`);
+			throw new Error(`Invalid output from exe '${exe}'. Line neither indicated '0' nor '1': ${line}`);
 		}
 	}
 

--- a/src/spec/pkg/README.md
+++ b/src/spec/pkg/README.md
@@ -1,0 +1,21 @@
+# `pkg` Packages
+
+These are "upstream" packages that test installation behavior of
+`esmakefile-cmake`. They are intended to be automatically
+packaged as part of an automated test and installed. Tests that
+depend on these packages being installed should go in the
+`downstream` directory. These `pkg` packages may depend on
+`upstream` packages that rely not on `esmakefile-cmake` to be
+installed.
+
+# Structure
+
+Every child directory of `pkg` should have a `make.ts` file who
+has a named `Distribution` to be packaged.
+
+The following are the packages:
+
+| name | version |
+|------|---------|
+| a    | 0.1.0   |
+|      |         |

--- a/src/spec/pkg/README.md
+++ b/src/spec/pkg/README.md
@@ -16,6 +16,6 @@ has a named `Distribution` to be packaged.
 The following are the packages:
 
 | name | version |
-|------|---------|
+| ---- | ------- |
 | a    | 0.1.0   |
 |      |         |

--- a/src/spec/pkg/a/LICENSE.txt
+++ b/src/spec/pkg/a/LICENSE.txt
@@ -1,0 +1,1 @@
+Fake license for 'a'

--- a/src/spec/pkg/a/include/a/a.h
+++ b/src/spec/pkg/a/include/a/a.h
@@ -1,0 +1,6 @@
+#ifndef A_H
+#define A_H
+
+char a();
+
+#endif

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -42,7 +42,6 @@ cli((make) => {
 		},
 	});
 
-	/*
 	const hello = d.findPackage({
 		pkgconfig: 'hello',
 		cmake: {
@@ -51,16 +50,6 @@ cli((make) => {
 			libraryTarget: 'HelloWorld::hello',
 		},
 	});
-
-	const world = d.findPackage({
-		pkgconfig: 'world',
-		cmake: {
-			packageName: 'HelloWorld',
-			component: 'world',
-			libraryTarget: 'HelloWorld::world',
-		},
-	});
- */
 
 	const genC = Path.build('gen.c');
 
@@ -71,7 +60,7 @@ cli((make) => {
 	d.addExecutable({
 		name: 'e1',
 		src: ['src/e1.c', genC],
-		linkTo: [zero, one, two]
+		linkTo: [zero, one, two, hello]
 	});
 
 	d.addLibrary({

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -18,7 +18,8 @@
  */
 
 import { Distribution } from '../../../index.js';
-import { cli } from 'esmakefile';
+import { cli, Path } from 'esmakefile';
+import { writeFile } from 'node:fs/promises';
 
 cli((make) => {
 	const d = new Distribution(make, {
@@ -26,9 +27,15 @@ cli((make) => {
 		version: '0.1.0'
 	});
 
+	const genC = Path.build('gen.c');
+
+	make.add(genC, (args) => {
+		return writeFile(args.abs(genC), 'int gen12() { return 12; }');
+	});
+
 	d.addExecutable({
 		name: 'e1',
-		src: ['src/e1.c']
+		src: ['src/e1.c', genC]
 	});
 
 	d.addLibrary({

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -29,12 +29,12 @@ cli((make) => {
 
 	const zero = d.findPackage('zero');
 
-	/*
 	const one = d.findPackage({
 		pkgconfig: 'libone',
 		cmake: 'one',
 	});
 
+	/*
 	const two = d.findPackage({
 		pkgconfig: 'two',
 		cmake: {
@@ -72,7 +72,7 @@ cli((make) => {
 	d.addExecutable({
 		name: 'e1',
 		src: ['src/e1.c', genC],
-		linkTo: [zero]
+		linkTo: [zero, one]
 	});
 
 	d.addLibrary({

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -63,6 +63,11 @@ cli((make) => {
 		linkTo: [zero, one, two, hello]
 	});
 
+	d.addTest({
+		name: 't1',
+		src: ['test/t1.c']
+	});
+
 	d.addLibrary({
 		name: 'a',
 		src: ['src/a.c']

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -51,7 +51,7 @@ cli((make) => {
 		},
 	});
 
-	const genC = Path.build('gen.c');
+	const genC = Path.build('src/gen.c');
 
 	make.add(genC, (args) => {
 		return writeFile(args.abs(genC), 'int gen12() { return 12; }');

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -24,7 +24,7 @@ import { writeFile } from 'node:fs/promises';
 cli((make) => {
 	const d = new Distribution(make, {
 		name: 'a',
-		version: '0.1.0'
+		version: '0.1.0',
 	});
 
 	const zero = d.findPackage('zero');
@@ -60,16 +60,16 @@ cli((make) => {
 	d.addExecutable({
 		name: 'e1',
 		src: ['src/e1.c', genC],
-		linkTo: [zero, one, two, hello]
+		linkTo: [zero, one, two, hello],
 	});
 
 	d.addTest({
 		name: 't1',
-		src: ['test/t1.c']
+		src: ['test/t1.c'],
 	});
 
 	d.addLibrary({
 		name: 'a',
-		src: ['src/a.c']
+		src: ['src/a.c'],
 	});
 });

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -26,6 +26,11 @@ cli((make) => {
 		version: '0.1.0'
 	});
 
+	d.addExecutable({
+		name: 'e1',
+		src: ['src/e1.c']
+	});
+
 	d.addLibrary({
 		name: 'a',
 		src: ['src/a.c']

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -34,16 +34,15 @@ cli((make) => {
 		cmake: 'one',
 	});
 
-	/*
 	const two = d.findPackage({
 		pkgconfig: 'two',
 		cmake: {
 			packageName: 'Two2',
-			version: '2',
 			libraryTarget: 'two',
 		},
 	});
 
+	/*
 	const hello = d.findPackage({
 		pkgconfig: 'hello',
 		cmake: {
@@ -72,7 +71,7 @@ cli((make) => {
 	d.addExecutable({
 		name: 'e1',
 		src: ['src/e1.c', genC],
-		linkTo: [zero, one]
+		linkTo: [zero, one, two]
 	});
 
 	d.addLibrary({

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -27,6 +27,42 @@ cli((make) => {
 		version: '0.1.0'
 	});
 
+	const zero = d.findPackage('zero');
+
+	/*
+	const one = d.findPackage({
+		pkgconfig: 'libone',
+		cmake: 'one',
+	});
+
+	const two = d.findPackage({
+		pkgconfig: 'two',
+		cmake: {
+			packageName: 'Two2',
+			version: '2',
+			libraryTarget: 'two',
+		},
+	});
+
+	const hello = d.findPackage({
+		pkgconfig: 'hello',
+		cmake: {
+			packageName: 'HelloWorld',
+			component: 'hello',
+			libraryTarget: 'HelloWorld::hello',
+		},
+	});
+
+	const world = d.findPackage({
+		pkgconfig: 'world',
+		cmake: {
+			packageName: 'HelloWorld',
+			component: 'world',
+			libraryTarget: 'HelloWorld::world',
+		},
+	});
+ */
+
 	const genC = Path.build('gen.c');
 
 	make.add(genC, (args) => {
@@ -35,7 +71,8 @@ cli((make) => {
 
 	d.addExecutable({
 		name: 'e1',
-		src: ['src/e1.c', genC]
+		src: ['src/e1.c', genC],
+		linkTo: [zero]
 	});
 
 	d.addLibrary({

--- a/src/spec/pkg/a/make.ts
+++ b/src/spec/pkg/a/make.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Nicholas Gulachek
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+
+import { Distribution } from '../../../index.js';
+import { cli } from 'esmakefile';
+
+cli((make) => {
+	const d = new Distribution(make, {
+		name: 'a',
+		version: '0.1.0'
+	});
+
+	d.addLibrary({
+		name: 'a',
+		src: ['src/a.c']
+	});
+});

--- a/src/spec/pkg/a/src/a.c
+++ b/src/spec/pkg/a/src/a.c
@@ -1,0 +1,3 @@
+#include "a/a.h"
+
+char a() { return 'a'; }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -1,0 +1,3 @@
+int main() {
+	return 0;
+}

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <one.h>
+#include <two.h>
 
 extern int gen12();
 
@@ -25,5 +26,10 @@ int main() {
 	 * one was referenced with findPackage({ cmake: 'one', ... })
 	 */
 	printf("e2e.addExecutable.findPackage-explicit-cmake-name-install = %d\n", one() == 1);
+
+	/*
+	 * two was referenced with findPackage with { cmake: { name: ..., libraryTarget: ... } }
+	 */
+	printf("e2e.addExecutable.findPackage-explicit-cmake-target-install = %d\n", two() == 2);
 	return 0;
 }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -14,5 +14,11 @@ int main() {
 	 * validates that the generated file was packaged correctly.
 	 */
 	printf("e2e.addExecutable.packages-generated-src = %d\n", gen12() == 12);
+
+	/*
+	 * zero was referenced with findPackage('zero')
+	 */
+	printf("e2e.addExecutable.findPackage-pc-cmake-same-install = %d\n", ZERO == 0);
+
 	return 0;
 }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <one.h>
 
 extern int gen12();
 
@@ -20,5 +21,9 @@ int main() {
 	 */
 	printf("e2e.addExecutable.findPackage-pc-cmake-same-install = %d\n", ZERO == 0);
 
+	/*
+	 * one was referenced with findPackage({ cmake: 'one', ... })
+	 */
+	printf("e2e.addExecutable.findPackage-explicit-cmake-name-install = %d\n", one() == 1);
 	return 0;
 }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -19,7 +19,7 @@ int main() {
 	/*
 	 * zero was referenced with findPackage('zero')
 	 */
-	printf("e2e.addExecutable.findPackage-pc-cmake-same-install = %d\n", ZERO == 0);
+	printf("e2e.addExecutable.findPackage-implicit-cmake-name-install = %d\n", ZERO == 0);
 
 	/*
 	 * one was referenced with findPackage({ cmake: 'one', ... })

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -12,39 +12,35 @@ int main() {
    * Assuming this will be run from vendor/bin after installing, this
    * proves that the exe is installed correctly
    */
-  printf("e2e.addExecutable.install-to-bin = 1\n");
+  printf("e2e.dist.exe-install-to-bin = 1\n");
 
   /*
    * This comes from a generated file. Assuming run from install, this
    * validates that the generated file was packaged correctly.
    */
-  printf("e2e.addExecutable.packages-generated-src = %d\n", gen12() == 12);
+  printf("e2e.dist.packages-generated-src = %d\n", gen12() == 12);
 
   /*
    * zero was referenced with findPackage('zero')
    */
-  printf("e2e.addExecutable.findPackage-implicit-cmake-name-install = %d\n",
-         ZERO == 0);
+  printf("e2e.dist.findPackage-implicit-cmake-name = %d\n", ZERO == 0);
 
   /*
    * one was referenced with findPackage({ cmake: 'one', ... })
    */
-  printf("e2e.addExecutable.findPackage-explicit-cmake-name-install = %d\n",
-         one() == 1);
+  printf("e2e.dist.findPackage-explicit-cmake-name = %d\n", one() == 1);
 
   /*
    * two was referenced with findPackage with { cmake: { name: ...,
    * libraryTarget: ... } }
    */
-  printf("e2e.addExecutable.findPackage-explicit-cmake-target-install = %d\n",
-         two() == 2);
+  printf("e2e.dist.findPackage-explicit-cmake-target = %d\n", two() == 2);
 
   /*
    * hello was referenced with findPackage with { cmake: { ..., component: ... }
    * }
    */
-  printf(
-      "e2e.addExecutable.findPackage-explicit-cmake-component-install = %d\n",
-      strcmp(hello(), "hello") == 0);
+  printf("e2e.dist.findPackage-explicit-cmake-component = %d\n",
+         strcmp(hello(), "hello") == 0);
   return 0;
 }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -1,3 +1,10 @@
+#include <stdio.h>
+
 int main() {
+	/*
+	 * Assuming this  will be run from vendor/bin after installing, this
+	 * proves that the exe is installed correctly
+	 */
+	printf("e2e.addExecutable.install-to-bin = pass\n");
 	return 0;
 }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -1,6 +1,9 @@
-#include <stdio.h>
 #include <one.h>
 #include <two.h>
+#include <hello.h>
+
+#include <stdio.h>
+#include <string.h>
 
 extern int gen12();
 
@@ -31,5 +34,10 @@ int main() {
 	 * two was referenced with findPackage with { cmake: { name: ..., libraryTarget: ... } }
 	 */
 	printf("e2e.addExecutable.findPackage-explicit-cmake-target-install = %d\n", two() == 2);
+
+	/*
+	 * hello was referenced with findPackage with { cmake: { ..., component: ... } }
+	 */
+	printf("e2e.addExecutable.findPackage-explicit-cmake-component-install = %d\n", strcmp(hello(), "hello") == 0);
 	return 0;
 }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -1,6 +1,6 @@
+#include <hello.h>
 #include <one.h>
 #include <two.h>
-#include <hello.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -8,36 +8,43 @@
 extern int gen12();
 
 int main() {
-	/*
-	 * Assuming this will be run from vendor/bin after installing, this
-	 * proves that the exe is installed correctly
-	 */
-	printf("e2e.addExecutable.install-to-bin = 1\n");
+  /*
+   * Assuming this will be run from vendor/bin after installing, this
+   * proves that the exe is installed correctly
+   */
+  printf("e2e.addExecutable.install-to-bin = 1\n");
 
-	/*
-	 * This comes from a generated file. Assuming run from install, this
-	 * validates that the generated file was packaged correctly.
-	 */
-	printf("e2e.addExecutable.packages-generated-src = %d\n", gen12() == 12);
+  /*
+   * This comes from a generated file. Assuming run from install, this
+   * validates that the generated file was packaged correctly.
+   */
+  printf("e2e.addExecutable.packages-generated-src = %d\n", gen12() == 12);
 
-	/*
-	 * zero was referenced with findPackage('zero')
-	 */
-	printf("e2e.addExecutable.findPackage-implicit-cmake-name-install = %d\n", ZERO == 0);
+  /*
+   * zero was referenced with findPackage('zero')
+   */
+  printf("e2e.addExecutable.findPackage-implicit-cmake-name-install = %d\n",
+         ZERO == 0);
 
-	/*
-	 * one was referenced with findPackage({ cmake: 'one', ... })
-	 */
-	printf("e2e.addExecutable.findPackage-explicit-cmake-name-install = %d\n", one() == 1);
+  /*
+   * one was referenced with findPackage({ cmake: 'one', ... })
+   */
+  printf("e2e.addExecutable.findPackage-explicit-cmake-name-install = %d\n",
+         one() == 1);
 
-	/*
-	 * two was referenced with findPackage with { cmake: { name: ..., libraryTarget: ... } }
-	 */
-	printf("e2e.addExecutable.findPackage-explicit-cmake-target-install = %d\n", two() == 2);
+  /*
+   * two was referenced with findPackage with { cmake: { name: ...,
+   * libraryTarget: ... } }
+   */
+  printf("e2e.addExecutable.findPackage-explicit-cmake-target-install = %d\n",
+         two() == 2);
 
-	/*
-	 * hello was referenced with findPackage with { cmake: { ..., component: ... } }
-	 */
-	printf("e2e.addExecutable.findPackage-explicit-cmake-component-install = %d\n", strcmp(hello(), "hello") == 0);
-	return 0;
+  /*
+   * hello was referenced with findPackage with { cmake: { ..., component: ... }
+   * }
+   */
+  printf(
+      "e2e.addExecutable.findPackage-explicit-cmake-component-install = %d\n",
+      strcmp(hello(), "hello") == 0);
+  return 0;
 }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -1,10 +1,18 @@
 #include <stdio.h>
 
+extern int gen12();
+
 int main() {
 	/*
-	 * Assuming this  will be run from vendor/bin after installing, this
+	 * Assuming this will be run from vendor/bin after installing, this
 	 * proves that the exe is installed correctly
 	 */
-	printf("e2e.addExecutable.install-to-bin = pass\n");
+	printf("e2e.addExecutable.install-to-bin = 1\n");
+
+	/*
+	 * This comes from a generated file. Assuming run from install, this
+	 * validates that the generated file was packaged correctly.
+	 */
+	printf("e2e.addExecutable.packages-generated-src = %d\n", gen12() == 12);
 	return 0;
 }

--- a/src/spec/pkg/a/test/t1.c
+++ b/src/spec/pkg/a/test/t1.c
@@ -1,0 +1,3 @@
+int main() {
+	return 0;
+}

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -26,6 +26,10 @@ plan:
         prose: A source file given to addExecutable is a prereq of the output executable. When it updates, the executable needs to update, too.
       - case: multi-source-dev
         prose: Multiple sources can comprise an executable in a development build.
+      - case: default-include
+        prose: By default, an executable includes the `@src/include` directory.
+      - case: header-is-postreq
+        prose: Updating a header file required by a compilation makes an executable require updates.
       - case: links-c-cxx-as-cxx
         prose: When a C and C++ source (detected by extension) is given to addExecutable, the executable is linked with a C++ compiler.
       - case: install-to-bin

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -11,5 +11,9 @@ plan:
       - case: findPackage-explicit-cmake-name-install
         prose: >-
           An executable with a `linkTo` a `findPackage({ cmake: <name>, ... })` finds a
-          CMake package with that `name` and links to a library with `name`.
-
+          CMake package with that `name` and links to a library named `name`.
+      - case: findPackage-explicit-cmake-target-install
+        prose: >-
+          An executable with a `linkTo` a `findPackage({ cmake: { name: <name>,
+          libraryTarget: <target>, ... }, ... })` finds a CMake package with that `name` and
+          links to a library named `target`.

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -1,67 +1,73 @@
 group: e2e
 plan:
-  - group: Distribution
+  - group: dev
     plan:
-      - case: c11-dev-exe
-        prose: Specifying C11 makes a development build of a C executable target C11.
-      - case: c17-dev-exe
-        prose: Specifying C17 makes a development build of a C executable target C17.
-      - case: cxx17-dev-exe
-        prose: Specifying C++17 makes a development build of a C++ executable target C++17.
-      - case: cxx20-dev-exe
-        prose: Specifying C++20 makes a development build of a C++ executable target C++20.
-      - case: package-copies-license
+      - group: Distribution
+        plan:
+          - case: c11-exe
+            prose: Specifying C11 makes a development build of a C executable target C11.
+          - case: c17-exe
+            prose: Specifying C17 makes a development build of a C executable target C17.
+          - case: cxx17-exe
+            prose: Specifying C++17 makes a development build of a C++ executable target C++17.
+          - case: cxx20-exe
+            prose: Specifying C++20 makes a development build of a C++ executable target C++20.
+      - group: addExecutable
+        plan:
+          - case: source-is-prereq
+            prose: A source file given to addExecutable is a prereq of the output executable. When it updates, the executable needs to update, too.
+          - case: multi-source
+            prose: Multiple sources can comprise an executable in a development build.
+          - case: default-include
+            prose: By default, an executable includes the `@src/include` directory.
+          - case: header-is-postreq
+            prose: Updating a header file required by a compilation makes an executable require updates.
+          - case: links-c-cxx-as-cxx
+            prose: When a C and C++ source (detected by extension) is given to addExecutable, the executable is linked with a C++ compiler.
+      - group: addLibrary
+        plan:
+          - case: links-c-cxx-as-cxx
+            prose: When a C and C++ source (detected by extension) is given to addLibrary, the executable is linked with a C++ compiler.
+  - group: dist
+    plan:
+      - case: copies-license
         prose: Package creation copies `LICENSE.txt` from source into the package.
-      - case: package-copies-exe-static-src
+      - case: copies-exe-static-src
         prose: >-
           Package creation copies a source file given to `addExecutable` in source directory
           into package directory with same relative path.
-      - case: package-copies-exe-generated-src
+      - case: copies-exe-generated-src
         prose: >-
           Package creation copies a source file given to `addExecutable` in build directory
           into package directory with same relative path.
-  - group: addExecutable
-    plan:
-      - case: source-is-prereq
-        prose: A source file given to addExecutable is a prereq of the output executable. When it updates, the executable needs to update, too.
-      - case: multi-source-dev
-        prose: Multiple sources can comprise an executable in a development build.
-      - case: default-include
-        prose: By default, an executable includes the `@src/include` directory.
-      - case: header-is-postreq
-        prose: Updating a header file required by a compilation makes an executable require updates.
-      - case: links-c-cxx-as-cxx
-        prose: When a C and C++ source (detected by extension) is given to addExecutable, the executable is linked with a C++ compiler.
-      - case: install-to-bin
-        prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
-      - case: packages-generated-src
+      - case: packages-generated-src # TODO redundant
         prose: An executable that has a generated `src` file packages the generated file in the distribution.
-      - case: findPackage-implicit-cmake-name-install
+      - case: exe-install-to-bin
+        prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
+      - case: findPackage-implicit-cmake-name
         prose: An executable with a `linkTo` a `findPackage(<name>)` finds a CMake package with that `name` and links to a library with `name`.
-      - case: findPackage-explicit-cmake-name-install
+      - case: findPackage-explicit-cmake-name
         prose: >-
           An executable with a `linkTo` a `findPackage({ cmake: <name>, ... })` finds a
           CMake package with that `name` and links to a library named `name`.
-      - case: findPackage-explicit-cmake-target-install
+      - case: findPackage-explicit-cmake-target
         prose: >-
           An executable with a `linkTo` a `findPackage({ cmake: { name: <name>,
           libraryTarget: <target>, ... }, ... })` finds a CMake package with that `name` and
           links to a library named `target`.
-      - case: findPackage-explicit-cmake-component-install
+      - case: findPackage-explicit-cmake-component
         prose: >-
           An executable with a `linkTo` a `findPackage({ cmake: { name: <name>,
           libraryTarget: <target>, component: <component>, ... }, ... })` finds a CMake package
           with that `name` with a component named `component` and links to a library named
           `target`.
-  - group: addLibrary
-    plan:
-      - case: installs-pkgconfig
-        prose: A library installs a `.pc` file that links to the library with the same name as the library.
-      - case: installs-cmake-config
-        prose: A library installs a CMake config file that links to the library with the same name as the library.
-      - case: links-c-cxx-as-cxx
-        prose: When a C and C++ source (detected by extension) is given to addLibrary, the executable is linked with a C++ compiler.
-  - group: addTest
-    plan:
-      - case: omitted-from-package
+      - case: test-omitted-from-package
         prose: After creating a package, source provided to `addTest` is not copied to the package.
+  - group: cm-pkg
+    plan:
+      - case: name
+        prose: A library installs a CMake config file that links to the library with the same name as the library.
+  - group: pc-pkg
+    plan:
+      - case: name
+        prose: A library created with `addLibrary` installs a `.pc` file that is linked with the same name as the library.

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -1,5 +1,9 @@
 group: e2e
 plan:
+  - group: Distribution
+    plan:
+      - case: package-copies-license
+        prose: Package creation copies `LICENSE.txt` from source into the package.
   - group: addExecutable
     plan:
       - case: install-to-bin

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -2,6 +2,8 @@ group: e2e
 plan:
   - group: Distribution
     plan:
+      - case: c11-dev-exe
+        prose: Specifying C11 makes a development build of a C executable target C11.
       - case: package-copies-license
         prose: Package creation copies `LICENSE.txt` from source into the package.
       - case: package-copies-exe-static-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -6,6 +6,10 @@ plan:
         prose: Specifying C11 makes a development build of a C executable target C11.
       - case: c17-dev-exe
         prose: Specifying C17 makes a development build of a C executable target C17.
+      - case: cxx17-dev-exe
+        prose: Specifying C++17 makes a development build of a C++ executable target C++17.
+      - case: cxx20-dev-exe
+        prose: Specifying C++20 makes a development build of a C++ executable target C++20.
       - case: package-copies-license
         prose: Package creation copies `LICENSE.txt` from source into the package.
       - case: package-copies-exe-static-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -18,6 +18,8 @@ plan:
         prose: A source file given to addExecutable is a prereq of the output executable. When it updates, the executable needs to update, too.
       - case: multi-source-dev
         prose: Multiple sources can comprise an executable in a development build.
+      - case: links-c-cxx-as-cxx
+        prose: When a C and C++ source (detected by extension) is given to addExecutable, the executable is linked with a C++ compiler.
       - case: install-to-bin
         prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
       - case: packages-generated-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -14,6 +14,8 @@ plan:
           into package directory with same relative path.
   - group: addExecutable
     plan:
+      - case: source-is-prereq
+        prose: A source file given to addExecutable is a prereq of the output executable. When it updates, the executable needs to update, too.
       - case: install-to-bin
         prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
       - case: packages-generated-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -1,17 +1,21 @@
 group: e2e
 plan:
-  - group: include
+  - group: addExecutable
     plan:
-      - case: default-src
-        prose: By default, the `@src/include` dir is included at compile time.
-        systems: [esm, cmake] # default
-        types: [exe, lib, test] # default
-      - case: default-build
-        prose: By default, the `@build/include` dir is included at compile time.
-      - case: specify
-        prose: When `includeDirs` are specified, they are included at compile time.
-      - case: specify-keeps-src
-        prose: When `includeDirs` are specified, `@src/include` is still included.
-      - case: specify-keeps-build
-        prose: When `includeDirs` are specified, `@build/include` is still included.
+      - case: install-to-bin
+        prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
+          # - group: include
+          #   plan:
+          #     - case: default-src
+          #       prose: By default, the `@src/include` dir is included at compile time.
+          #       systems: [esm, cmake] # default
+          #       types: [exe, lib, test] # default
+          #     - case: default-build
+          #       prose: By default, the `@build/include` dir is included at compile time.
+          #     - case: specify
+          #       prose: When `includeDirs` are specified, they are included at compile time.
+          #     - case: specify-keeps-src
+          #       prose: When `includeDirs` are specified, `@src/include` is still included.
+          #     - case: specify-keeps-build
+          #       prose: When `includeDirs` are specified, `@build/include` is still included.
 

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -5,7 +5,9 @@ plan:
       - case: install-to-bin
         prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
       - case: packages-generated-src
-        prose: An executable created with `addExecutable` that has a generated `src` file packages the generated file in the distribution.
+        prose: An executable that has a generated `src` file packages the generated file in the distribution.
+      - case: findPackage-pc-cmake-same-install
+        prose: An executable with a `linkTo` a `findPackage(<name>)` finds a CMake package with that `name` and links to a library with `name`.
           # - group: include
           #   plan:
           #     - case: default-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -38,7 +38,9 @@ plan:
   - group: addLibrary
     plan:
       - case: installs-pkgconfig
-        prose: A library installs a `.pc` file with the same name as the library that links to the library.
+        prose: A library installs a `.pc` file that links to the library with the same name as the library.
+      - case: installs-cmake-config
+        prose: A library installs a CMake config file that links to the library with the same name as the library.
   - group: addTest
     plan:
       - case: omitted-from-package

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -8,3 +8,8 @@ plan:
         prose: An executable that has a generated `src` file packages the generated file in the distribution.
       - case: findPackage-pc-cmake-same-install
         prose: An executable with a `linkTo` a `findPackage(<name>)` finds a CMake package with that `name` and links to a library with `name`.
+      - case: findPackage-explicit-cmake-name-install
+        prose: >-
+          An executable with a `linkTo` a `findPackage({ cmake: <name>, ... })` finds a
+          CMake package with that `name` and links to a library with `name`.
+

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -35,6 +35,10 @@ plan:
           libraryTarget: <target>, component: <component>, ... }, ... })` finds a CMake package
           with that `name` with a component named `component` and links to a library named
           `target`.
+  - group: addLibrary
+    plan:
+      - case: installs-pkgconfig
+        prose: A library installs a `.pc` file with the same name as the library that links to the library.
   - group: addTest
     plan:
       - case: omitted-from-package

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -6,7 +6,7 @@ plan:
         prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
       - case: packages-generated-src
         prose: An executable that has a generated `src` file packages the generated file in the distribution.
-      - case: findPackage-pc-cmake-same-install
+      - case: findPackage-implicit-cmake-name-install
         prose: An executable with a `linkTo` a `findPackage(<name>)` finds a CMake package with that `name` and links to a library with `name`.
       - case: findPackage-explicit-cmake-name-install
         prose: >-

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -12,6 +12,8 @@ plan:
             prose: Specifying C++17 makes a development build of a C++ executable target C++17.
           - case: cxx20-exe
             prose: Specifying C++20 makes a development build of a C++ executable target C++20.
+          - case: test-target
+            prose: A `Distribution` will have a test recipe called 'test-<dist-name>' that runs all tests.
       - group: addExecutable
         plan:
           - case: source-is-prereq
@@ -28,10 +30,30 @@ plan:
             prose: The include directories of a direct library dependency are included in the executable's compile.
           - case: links-transitive-library
             prose: The symbols from a transitive library in a `Distribution` are linked to an executable.
+          - case: can-link-to-other-distribution
+            prose: A library created with one `Distribution` can be linked to an executable in another `Distribution`.
       - group: addLibrary
         plan:
           - case: links-c-cxx-as-cxx
             prose: When a C and C++ source (detected by extension) is given to addLibrary, the executable is linked with a C++ compiler.
+          - case: can-link-to-other-distribution
+            prose: A library created with one `Distribution` can be linked to a library in another `Distribution`.
+          - case: type-static-implicit-default
+            prose: A library is by default linked as a static library.
+          - case: type-static-explicit-default
+            prose: A library is by linked as a static library by default when given type `default`.
+          - case: type-explicit-static
+            prose: A library is by linked as a static library by default when given type `static`.
+          - case: type-explicit-dynamic
+            prose: A library is by linked as a dynamic library by default when given type `dynamic`.
+          - case: type-config-dynamic-implicit-default
+            prose: >-
+              A library is by linked as a dynamic library when `esmakefile-cmake.config.json` has `buildSharedLibs: true`
+              and the library has no explicit type.
+          - case: type-config-dynamic-explicit-default
+            prose: >-
+              A library is by linked as a dynamic library when `esmakefile-cmake.config.json` has `buildSharedLibs: true`
+              and the library has type `default`.
       - group: findPackage
         plan:
           - case: searches-pkgconfig-by-name
@@ -47,6 +69,18 @@ plan:
               A name specific to `pkg-config` can be given by calling `findPackage({ pkgconfig: 'name' })`.
           - case: fails-incompatible-version
             prose: The build fails if an incompatible `pkg-config` version is given to `findPackage`.
+      - group: addTest
+        plan:
+          - case: returns-obj-with-run
+            prose: Returns an object with a `run` target that will run the test.
+          - case: returns-obj-with-binary
+            prose: Returns an object with a `binary` target that is the test's executable binary.
+      - group: addCompileCommands
+        plan:
+          - case: generates-json-db
+            prose: >-
+              The target returned by `addCompileCommands` generates a `compile-commands.json` file that's
+              compatible with `clang-check`.
   - group: dist
     plan:
       - case: copies-license
@@ -82,6 +116,10 @@ plan:
           `target`.
       - case: test-omitted-from-package
         prose: After creating a package, source provided to `addTest` is not copied to the package.
+      - group: findPackage
+        plan:
+          - case: can-specify-version
+            prose: A version given to `findPackage` can specify a CMake version.
   - group: cm-pkg
     plan:
       - case: name

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -4,6 +4,14 @@ plan:
     plan:
       - case: package-copies-license
         prose: Package creation copies `LICENSE.txt` from source into the package.
+      - case: package-copies-exe-static-src
+        prose: >-
+          Package creation copies a source file given to `addExecutable` in source directory
+          into package directory with same relative path.
+      - case: package-copies-exe-generated-src
+        prose: >-
+          Package creation copies a source file given to `addExecutable` in build directory
+          into package directory with same relative path.
   - group: addExecutable
     plan:
       - case: install-to-bin

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -23,3 +23,7 @@ plan:
           libraryTarget: <target>, component: <component>, ... }, ... })` finds a CMake package
           with that `name` with a component named `component` and links to a library named
           `target`.
+  - group: addTest
+    plan:
+      - case: omitted-from-package
+        prose: After creating a package, source provided to `addTest` is not copied to the package.

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -47,6 +47,8 @@ plan:
         prose: A library installs a `.pc` file that links to the library with the same name as the library.
       - case: installs-cmake-config
         prose: A library installs a CMake config file that links to the library with the same name as the library.
+      - case: links-c-cxx-as-cxx
+        prose: When a C and C++ source (detected by extension) is given to addLibrary, the executable is linked with a C++ compiler.
   - group: addTest
     plan:
       - case: omitted-from-package

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -42,6 +42,9 @@ plan:
             prose: The object returned by `findPackage` can be given to `linkTo` for `addLibrary`.
           - case: can-specify-version
             prose: A `pkg-config` version can be specified like `findPackage('name = 1.2.3')`.
+          - case: can-specify-explicit-pkgconfig-name
+            prose: >-
+              A name specific to `pkg-config` can be given by calling `findPackage({ pkgconfig: 'name' })`.
           - case: fails-incompatible-version
             prose: The build fails if an incompatible `pkg-config` version is given to `findPackage`.
   - group: dist

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -17,3 +17,9 @@ plan:
           An executable with a `linkTo` a `findPackage({ cmake: { name: <name>,
           libraryTarget: <target>, ... }, ... })` finds a CMake package with that `name` and
           links to a library named `target`.
+      - case: findPackage-explicit-cmake-component-install
+        prose: >-
+          An executable with a `linkTo` a `findPackage({ cmake: { name: <name>,
+          libraryTarget: <target>, component: <component>, ... }, ... })` finds a CMake package
+          with that `name` with a component named `component` and links to a library named
+          `target`.

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -24,10 +24,26 @@ plan:
             prose: Updating a header file required by a compilation makes an executable require updates.
           - case: links-c-cxx-as-cxx
             prose: When a C and C++ source (detected by extension) is given to addExecutable, the executable is linked with a C++ compiler.
+          - case: includes-direct-dependency-dirs
+            prose: The include directories of a direct library dependency are included in the executable's compile.
+          - case: links-transitive-library
+            prose: The symbols from a transitive library in a `Distribution` are linked to an executable.
       - group: addLibrary
         plan:
           - case: links-c-cxx-as-cxx
             prose: When a C and C++ source (detected by extension) is given to addLibrary, the executable is linked with a C++ compiler.
+      - group: findPackage
+        plan:
+          - case: searches-pkgconfig-by-name
+            prose: When given just a name, `findPackage` will find a `pkg-config` package by the name given.
+          - case: can-link-to-exe
+            prose: The object returned by `findPackage` can be given to `linkTo` for `addExecutable`.
+          - case: can-link-to-lib
+            prose: The object returned by `findPackage` can be given to `linkTo` for `addLibrary`.
+          - case: can-specify-version
+            prose: A `pkg-config` version can be specified like `findPackage('name = 1.2.3')`.
+          - case: fails-incompatible-version
+            prose: The build fails if an incompatible `pkg-config` version is given to `findPackage`.
   - group: dist
     plan:
       - case: copies-license

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -16,6 +16,8 @@ plan:
     plan:
       - case: source-is-prereq
         prose: A source file given to addExecutable is a prereq of the output executable. When it updates, the executable needs to update, too.
+      - case: multi-source-dev
+        prose: Multiple sources can comprise an executable in a development build.
       - case: install-to-bin
         prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
       - case: packages-generated-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -8,18 +8,3 @@ plan:
         prose: An executable that has a generated `src` file packages the generated file in the distribution.
       - case: findPackage-pc-cmake-same-install
         prose: An executable with a `linkTo` a `findPackage(<name>)` finds a CMake package with that `name` and links to a library with `name`.
-          # - group: include
-          #   plan:
-          #     - case: default-src
-          #       prose: By default, the `@src/include` dir is included at compile time.
-          #       systems: [esm, cmake] # default
-          #       types: [exe, lib, test] # default
-          #     - case: default-build
-          #       prose: By default, the `@build/include` dir is included at compile time.
-          #     - case: specify
-          #       prose: When `includeDirs` are specified, they are included at compile time.
-          #     - case: specify-keeps-src
-          #       prose: When `includeDirs` are specified, `@src/include` is still included.
-          #     - case: specify-keeps-build
-          #       prose: When `includeDirs` are specified, `@build/include` is still included.
-

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -4,6 +4,8 @@ plan:
     plan:
       - case: install-to-bin
         prose: When installed, an executable created with `addExecutable` is available in `<prefix>/bin`.
+      - case: packages-generated-src
+        prose: An executable created with `addExecutable` that has a generated `src` file packages the generated file in the distribution.
           # - group: include
           #   plan:
           #     - case: default-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -4,6 +4,8 @@ plan:
     plan:
       - case: c11-dev-exe
         prose: Specifying C11 makes a development build of a C executable target C11.
+      - case: c17-dev-exe
+        prose: Specifying C17 makes a development build of a C executable target C17.
       - case: package-copies-license
         prose: Package creation copies `LICENSE.txt` from source into the package.
       - case: package-copies-exe-static-src

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -1,0 +1,17 @@
+group: e2e
+plan:
+  - group: include
+    plan:
+      - case: default-src
+        prose: By default, the `@src/include` dir is included at compile time.
+        systems: [esm, cmake] # default
+        types: [exe, lib, test] # default
+      - case: default-build
+        prose: By default, the `@build/include` dir is included at compile time.
+      - case: specify
+        prose: When `includeDirs` are specified, they are included at compile time.
+      - case: specify-keeps-src
+        prose: When `includeDirs` are specified, `@src/include` is still included.
+      - case: specify-keeps-build
+        prose: When `includeDirs` are specified, `@build/include` is still included.
+

--- a/src/spec/upstream/CMakeLists.txt
+++ b/src/spec/upstream/CMakeLists.txt
@@ -32,6 +32,7 @@ project(TestUpstream)
 # same as target_link_libraries argument
 #
 
+add_subdirectory(zero)
 add_subdirectory(one)
 add_subdirectory(two)
 

--- a/src/spec/upstream/zero/CMakeLists.txt
+++ b/src/spec/upstream/zero/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+project(zero VERSION 0)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(FILES pkgconfig/zero.pc
+	DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+
+install(FILES cmake/zero-config.cmake
+	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zero"
+)

--- a/src/spec/upstream/zero/cmake/zero-config.cmake
+++ b/src/spec/upstream/zero/cmake/zero-config.cmake
@@ -1,0 +1,2 @@
+add_library(zero INTERFACE)
+target_compile_definitions(zero INTERFACE ZERO=0)

--- a/src/spec/upstream/zero/pkgconfig/zero.pc
+++ b/src/spec/upstream/zero/pkgconfig/zero.pc
@@ -1,0 +1,5 @@
+Name: zero
+Version: 0
+Description: nada
+
+Cflags: -DZERO=0

--- a/test-plan.md
+++ b/test-plan.md
@@ -62,3 +62,49 @@ and a `CMakeLists.txt` file to test downstream consumption.
 These tests currently live in `src/spec/DistributionSpec.ts`.
 
 > **TODO**: This should be reorganized (issue 30).
+
+## Structure
+
+Due to the large number of files that are generated, this file
+serves to document the output structure of the `.test`
+directory.
+
+The main `src/spec/e2e.ts` script is run with the current
+directory (git repo root) as the `--srcdir` and the `.test`
+directory as the `--outdir`.
+
+The `.test` dir has the following structure:
+
+```
+vendor/ <-- place for upstream packages to be installed
+  include/
+  lib/
+  build/ <-- place for upstream packages to be built
+  ...
+.test/ <-- disposable generated files
+  vendor/ <-- place for generated packages to be installed
+  pkg/
+outdir)
+    pack/ <-- generating a package (esmake --outdir)
+      pkg1/
+      ...
+    unpack/ <-- unpack generated tar here
+      pkg1/
+      ...
+    build/ <-- cmake build dir pre-install
+      pkg1/
+      ...
+  downstream/ <-- place for downstream builds to go
+    d1/
+      esmake/ <-- for esmakefile builds
+      cmake/ <-- for cmake builds
+    ...
+```
+
+Upstream packages are copied from `vendor` to `.test/vendor` to
+put everything in one directory (since that's a current
+limitation **TODO**) and rebuilding/reinstalling the upstream
+packages is a waste of time because these packages are
+independent of `esmakefile-cmake`.
+
+

--- a/test-plan.md
+++ b/test-plan.md
@@ -1,0 +1,64 @@
+# Test Plan
+
+This project focuses primarily on end-to-end tests to catch
+regressions and exercise functionality. This is because it's too
+often the case that something isn't quite as simple as it seems
+based on documentation, and it's important to prove that users
+will be able to compile, link, and run programs on supported
+compilers and operating systems.
+
+With the complexity of 
+- A development time build system
+- CMake package generation with parallel functionality to the
+   dev build system
+- Downstream package consumption of these generated packages
+  needing testing
+
+The tests are broken into a few different classifications as
+outlined below.
+
+## Development Only
+
+These tests _only_ apply to the development time build system,
+which should be a small bit of functionality. The test code
+currently resides in `src/spec/DistributionSpec.ts`.
+
+The functionality that should go here is
+- Build system dependency management (prereqs/postreqs update
+  build appropriately)
+- `compile-commands.json` generation
+- Unit test configuration
+
+## Upstream Packages
+
+These are test packages that the tests assume are installed in
+the system prior to being run. They live in `src/spec/upstream`
+and are installed with `cmake`.  
+
+If specific upstream configuration is needed, such as exercising
+the variations of `findPackage`, that should be added here.
+
+## Package Creation
+
+Functionality that impacts the generated package is part of
+this. These tests should exercise both development-time and
+package functionality of the equivalent feature, such as which
+directories are included in a build. which packages to find,
+which libraries to link, etc.
+
+These tests require that the upstream packages are installed on
+the system.
+
+The tests currently live in `src/spec/DistributionSpec.ts`.
+
+> **TODO**: This should be reorganized (issue 30).
+
+## Package Consumption
+
+The packages we generated must be usable from esmakefile-cmake
+and CMake, so these tests have both an esmakefile-cmake build
+and a `CMakeLists.txt` file to test downstream consumption.
+
+These tests currently live in `src/spec/DistributionSpec.ts`.
+
+> **TODO**: This should be reorganized (issue 30).

--- a/test-plan.md
+++ b/test-plan.md
@@ -7,10 +7,11 @@ based on documentation, and it's important to prove that users
 will be able to compile, link, and run programs on supported
 compilers and operating systems.
 
-With the complexity of 
+With the complexity of
+
 - A development time build system
 - CMake package generation with parallel functionality to the
-   dev build system
+  dev build system
 - Downstream package consumption of these generated packages
   needing testing
 
@@ -24,6 +25,7 @@ which should be a small bit of functionality. The test code
 currently resides in `src/spec/DistributionSpec.ts`.
 
 The functionality that should go here is
+
 - Build system dependency management (prereqs/postreqs update
   build appropriately)
 - `compile-commands.json` generation
@@ -33,7 +35,7 @@ The functionality that should go here is
 
 These are test packages that the tests assume are installed in
 the system prior to being run. They live in `src/spec/upstream`
-and are installed with `cmake`.  
+and are installed with `cmake`.
 
 If specific upstream configuration is needed, such as exercising
 the variations of `findPackage`, that should be added here.
@@ -106,5 +108,3 @@ put everything in one directory (since that's a current
 limitation **TODO**) and rebuilding/reinstalling the upstream
 packages is a waste of time because these packages are
 independent of `esmakefile-cmake`.
-
-


### PR DESCRIPTION
Redid test structure to fix #30. 

This is by no means pristine, but it runs significantly faster than it did before and opens the door for more avenues for testing various functionality, most notably downstream CMake packages.

See the `dev-docs/testing` directory for how to approach testing.

The main gist is that there's a `plan.yaml` file that outlines all test cases and describes what the important thing being tested is. Then tests identify which case they're testing and we make sure that all planned tests pass and all reported tests were planned.