### PR TITLE
24 support private includes

### DIFF
--- a/src/Distribution.ts
+++ b/src/Distribution.ts
@@ -29,11 +29,10 @@ import {
 	IImportedLibrary,
 	ILinkedCompilation,
 } from './Library.js';
-import { IConfig, readConfigFile } from './Config.js';
+import { readConfigFile } from './Config.js';
 import { mkdir, copyFile, writeFile, cp } from 'node:fs/promises';
 import { chdir, cwd } from 'node:process';
 import { platform } from 'node:os';
-import { readFileSync } from 'node:fs';
 import { PkgConfig } from 'espkg-config';
 import { dirname, resolve } from 'node:path';
 
@@ -162,7 +161,6 @@ export class Distribution {
 
 	private _compiler: ICompiler;
 	private _defaultLibraryType: ResolvedLibraryType = ResolvedLibraryType.static;
-	private _config: IConfig;
 	private _pkgSearchPaths: string[] = [];
 	private _pkg: PkgConfig;
 

--- a/src/Distribution.ts
+++ b/src/Distribution.ts
@@ -628,6 +628,12 @@ export class Distribution {
 					);
 				}
 
+				if (lib.privateIncludeDirs.length > 0) {
+					cmake.push(
+						`\ntarget_include_directories(${lib.name} PRIVATE private/include)`,
+					);
+				}
+
 				const pcReqs: string[] = [];
 				for (const p of lib.pkgs) {
 					cmake.push(

--- a/src/Distribution.ts
+++ b/src/Distribution.ts
@@ -493,7 +493,7 @@ export class Distribution {
 					const { cmake, pkgconfig } = p;
 					if (!cmake) {
 						args.logStream.write(
-							`'${c.name}' depends on a package without a cmake lookup name defined in findPackage (pkgconfig name: '${pkgconfig}')`,
+							`'${c.name}' depends on a package without a cmake lookup name defined in findPackage (pkgconfig name: '${pkgconfig}')\n`,
 						);
 						return false;
 					}
@@ -527,6 +527,14 @@ export class Distribution {
 					args.logStream.write(`Copy ${i} -> ${dest}\n`);
 					await cp(args.abs(i), args.abs(dest), { recursive: true });
 					args.logStream.write(`(done) Copy ${i} -> ${dest}\n`);
+				}
+
+				// Copy all private includes into dist/private/include
+				for (const pi of c.privateIncludeDirs) {
+					const dest = dir.join('private/include');
+					args.logStream.write(`Copy ${pi} -> ${dest}\n`);
+					await cp(args.abs(pi), args.abs(dest), { recursive: true });
+					args.logStream.write(`(done) Copy ${pi} -> ${dest}\n`);
 				}
 			}
 
@@ -570,8 +578,16 @@ export class Distribution {
 				}
 				cmake.push(')');
 
+				// Assumes that all headers are copied into include/
 				if (exe.includeDirs.length > 0) {
 					cmake.push(`target_include_directories(${exe.name} PRIVATE include)`);
+				}
+
+				// Assumes that all private headers are copied into private/include/
+				if (exe.privateIncludeDirs.length > 0) {
+					cmake.push(
+						`target_include_directories(${exe.name} PRIVATE private/include)`,
+					);
 				}
 
 				for (const p of exe.pkgs) {
@@ -589,7 +605,7 @@ export class Distribution {
 			const msvcPkgconfig = pkgconfig.join('msvc');
 
 			if (distLibs.length > 0) {
-				args.logStream.write(`Creating ${msvcPkgconfig}`);
+				args.logStream.write(`Creating ${msvcPkgconfig}\n`);
 				await mkdir(args.abs(msvcPkgconfig), { recursive: true });
 
 				// TODO only if installed
@@ -660,11 +676,11 @@ export class Distribution {
 				}
 
 				const pcFile = pkgconfig.join(`${lib.name}.pc`);
-				args.logStream.write(`Writing ${pcFile}`);
+				args.logStream.write(`Writing ${pcFile}\n`);
 				await writeFile(args.abs(pcFile), pc.join('\n'), 'utf8');
 
 				const msvcPcFile = msvcPkgconfig.join(`${lib.name}.pc`);
-				args.logStream.write(`Writing ${msvcPcFile}`);
+				args.logStream.write(`Writing ${msvcPcFile}\n`);
 				await writeFile(args.abs(msvcPcFile), msvcPc.join('\r\n'), 'utf8');
 
 				// TODO - only if installed
@@ -704,7 +720,7 @@ export class Distribution {
 				configContents.push(`check_required_components(${lib.name})`);
 
 				const configFile = cmakeDir.join(`${lib.name}-config.cmake.in`);
-				args.logStream.write(`Generating ${configFile}`);
+				args.logStream.write(`Generating ${configFile}\n`);
 				await writeFile(
 					args.abs(configFile),
 					configContents.join('\n'),

--- a/src/Distribution.ts
+++ b/src/Distribution.ts
@@ -226,6 +226,8 @@ export class Distribution {
 			includeDirs.push(Path.src('include'));
 		}
 
+		const privateIncludeDirs: Path[] = [Path.src('private/include')];
+
 		const linkTo: Library[] = [];
 		const pkgs: IImportedLibrary[] = [];
 		if (opts.linkTo) {
@@ -262,6 +264,7 @@ export class Distribution {
 			outDir: this.outDir,
 			src: opts.src.map((s) => Path.src(s)),
 			includeDirs,
+			privateIncludeDirs,
 			linkTo,
 			pkgs,
 			compileCommands: this.outDir.join(`.${opts.name}-compile_commands.json`),

--- a/src/GccCompiler.ts
+++ b/src/GccCompiler.ts
@@ -87,6 +87,10 @@ export class GccCompiler implements ICompiler {
 				return `-I${this.make.abs(i)}`;
 			});
 
+			for (const pi of c.privateIncludeDirs) {
+				includeFlags.push(`-I${this.make.abs(pi)}`);
+			}
+
 			// TODO postreqs
 			const { flags: pkgCflags } = await this._pkg.cflags(pkgDeps.names);
 

--- a/src/Library.ts
+++ b/src/Library.ts
@@ -96,6 +96,7 @@ export interface ILinkedCompilation {
 	outDir: IBuildPath;
 	src: Path[];
 	includeDirs: Path[];
+	privateIncludeDirs: Path[];
 	linkTo: Library[];
 	pkgs: IImportedLibrary[];
 	compileCommands: IBuildPath;

--- a/src/MsvcCompiler.ts
+++ b/src/MsvcCompiler.ts
@@ -71,6 +71,10 @@ export class MsvcCompiler implements ICompiler {
 				return `-I${this.make.abs(i)}`;
 			});
 
+			for (const pi of c.privateIncludeDirs) {
+				includeFlags.push(`-I${this.make.abs(pi)}`);
+			}
+
 			// TODO postreqs
 			const { flags: pkgCflags } = await this._pkg.cflags(pkgDeps.names);
 
@@ -98,6 +102,7 @@ export class MsvcCompiler implements ICompiler {
 			await dumpCompileCommands(args.abs(compileCommands), index);
 		});
 
+		// TODO - this isn't used. Is there an issue?
 		const includeFlags: string[] = [];
 		for (const i of c.includeDirs) {
 			includeFlags.push('/I', this.make.abs(i));

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -101,6 +101,7 @@ async function updateTarget(
 	let srcDir: string;
 	let buildDir: string;
 	let includeDir: string;
+	let privateIncludeDir: string;
 	let vendorDir: string;
 	let pkgconfigDir: string;
 
@@ -116,11 +117,13 @@ async function updateTarget(
 		srcDir = join(testDir, 'src');
 		buildDir = join(testDir, 'build');
 		includeDir = join(testDir, 'include');
+		privateIncludeDir = join(testDir, 'private', 'include');
 		vendorDir = join(testDir, 'vendor');
 		pkgconfigDir = join(vendorDir, 'lib', 'pkgconfig');
 
 		await mkdir(testDir, { recursive: true });
 		await mkdir(includeDir, { recursive: true });
+		await mkdir(privateIncludeDir, { recursive: true });
 		await mkdir(srcDir, { recursive: true });
 		const prevDir = cwd();
 		chdir(testDir);
@@ -189,6 +192,7 @@ async function updateTarget(
 	await test('dev1', async () => {
 		await writePath('include/hello.h', 'void hello();');
 		await writePath('include/punct.h', "#define PUNCT '!'");
+		await writePath('private/include/zero.h', '#define ZERO 0');
 
 		await writePath(
 			'src/hello.c',
@@ -200,7 +204,8 @@ async function updateTarget(
 		const main = addTextFile(
 			'src/main.c',
 			'#include "hello.h"',
-			'int main(){ hello(); return 0; }',
+			'#include "zero.h"',
+			'int main(){ hello(); return ZERO; }',
 		);
 
 		const d = new Distribution(make, {
@@ -218,6 +223,7 @@ async function updateTarget(
 				'e2e.dev.addExecutable.source-is-prereq',
 				'e2e.dev.addExecutable.multi-source',
 				'e2e.dev.addExecutable.default-include',
+				'e2e.dev.addExecutable.default-private-include',
 			],
 			() => expectOutput(hello.binary, 'hello!'),
 		);

--- a/src/spec/DistributionSpec.ts
+++ b/src/spec/DistributionSpec.ts
@@ -419,10 +419,12 @@ async function updateTarget(
 		await writePath('custom-include/add.h', 'int add(int a, int b);');
 
 		await writePath('include/zero.h', 'int zero();');
+		await writePath('private/include/zero_impl.h', '#define ZERO 0');
 		await writePath(
 			'src/zero.c',
 			'#include "zero.h"',
-			'int zero() { return 0; }',
+			'#include "zero_impl.h"',
+			'int zero() { return ZERO; }',
 		);
 
 		await writePath(
@@ -464,6 +466,8 @@ async function updateTarget(
 
 		await report(
 			[
+				'e2e.dev.addLibrary.default-include',
+				'e2e.dev.addLibrary.default-private-include',
 				'e2e.dev.addExecutable.links-transitive-library',
 				'e2e.dev.addExecutable.includes-direct-dependency-dirs',
 			],

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -22,7 +22,7 @@ import { cmake } from './cmake.js';
 import { installUpstream } from './upstream.js';
 import { resolve, join } from 'node:path';
 import { writeFile, readFile, rm } from 'node:fs/promises';
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { platform } from 'node:os';
 import { spawn } from 'node:child_process';
 import * as yaml from 'yaml';
@@ -352,8 +352,19 @@ cli((make) => {
 			prefixPath: [args.abs(pkgVendorDir), upstreamVendorDir],
 		});
 
+		const vAbs = args.abs(pkgVendorDir);
 		await cmake.build(pkgBuild, { config: 'Release' });
-		await cmake.install(pkgBuild, { prefix: args.abs(pkgVendorDir) });
+		await cmake.install(pkgBuild, { prefix: vAbs });
+
+		// We know that /.../a/private/include/secret.h is a private
+		// header
+		allResults.push({
+			id: 'e2e.dist.includes.skips-install-private',
+			passed: !(
+				existsSync(join(vAbs, 'include', 'secret.h')) ||
+				existsSync(join(vAbs, 'include', 'private', 'secret.h'))
+			),
+		});
 	});
 
 	make.add('run-e1', ['package-install'], async (args) => {

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -365,6 +365,13 @@ cli((make) => {
 				existsSync(join(vAbs, 'include', 'private', 'secret.h'))
 			),
 		});
+
+		// We know that a.c included secret.h, so if it succeeded
+		// building, then it was included
+		allResults.push({
+			id: 'e2e.dist.includes.lib-includes-private',
+			passed: true,
+		});
 	});
 
 	make.add('run-e1', ['package-install'], async (args) => {

--- a/src/spec/e2e.ts
+++ b/src/spec/e2e.ts
@@ -304,10 +304,9 @@ cli((make) => {
 		}
 
 		const list = await spawnAsync('tar', ['tzf', args.abs(aTarball)]);
-		const t1Index = list.indexOf('t1.c');
 		allResults.push({
 			id: 'e2e.dist.test-omitted-from-package',
-			passed: t1Index === -1,
+			passed: list.indexOf('t1.c') === -1,
 		});
 
 		const licenseTxt = await readFile(

--- a/src/spec/pkg/a/private/include/secret.h
+++ b/src/spec/pkg/a/private/include/secret.h
@@ -1,0 +1,6 @@
+#ifndef SECRET_H
+#define SECRET_H
+
+#define SECRET "in private include"
+
+#endif

--- a/src/spec/pkg/a/src/a.c
+++ b/src/spec/pkg/a/src/a.c
@@ -1,3 +1,8 @@
 #include "a/a.h"
+#include "secret.h"
+
+#ifndef SECRET
+#error "SECRET was not found, indicating that private/include was not included!"
+#endif
 
 char a() { return 'a'; }

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -27,7 +27,7 @@ int main() {
    */
   printf("e2e.dist.packages-generated-src = %d\n", gen12() == 12);
 
-  printf("e2e.dist.includes.includes-private = %d\n", SECRET_FOUND);
+  printf("e2e.dist.includes.exe-includes-private = %d\n", SECRET_FOUND);
   printf("e2e.dist.includes.copies-private = %d\n", SECRET_FOUND);
 
   /*

--- a/src/spec/pkg/a/src/e1.c
+++ b/src/spec/pkg/a/src/e1.c
@@ -5,6 +5,13 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "secret.h"
+#ifdef SECRET
+#define SECRET_FOUND 1
+#else
+#define SECRET_FOUND 0
+#endif
+
 extern int gen12();
 
 int main() {
@@ -19,6 +26,9 @@ int main() {
    * validates that the generated file was packaged correctly.
    */
   printf("e2e.dist.packages-generated-src = %d\n", gen12() == 12);
+
+  printf("e2e.dist.includes.includes-private = %d\n", SECRET_FOUND);
+  printf("e2e.dist.includes.copies-private = %d\n", SECRET_FOUND);
 
   /*
    * zero was referenced with findPackage('zero')

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -118,6 +118,12 @@ plan:
           `target`.
       - case: test-omitted-from-package
         prose: After creating a package, source provided to `addTest` is not copied to the package.
+      - group: includes
+        plan:
+          - case: includes-private
+            prose: The CMakeLists.txt will include private includes in the compile.
+          - case: copies-private
+            prose: Generating a distribution copies private include headers to private/include.
       - group: findPackage
         plan:
           - case: can-specify-version

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -124,6 +124,8 @@ plan:
             prose: The CMakeLists.txt will include private includes in the compile.
           - case: copies-private
             prose: Generating a distribution copies private include headers to private/include.
+          - case: skips-install-private
+            prose: A private header is not installed.
       - group: findPackage
         plan:
           - case: can-specify-version

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -124,8 +124,10 @@ plan:
         prose: After creating a package, source provided to `addTest` is not copied to the package.
       - group: includes
         plan:
-          - case: includes-private
-            prose: The CMakeLists.txt will include private includes in the compile.
+          - case: exe-includes-private
+            prose: The CMakeLists.txt will include private includes in the compile of an executable.
+          - case: lib-includes-private
+            prose: The CMakeLists.txt will include private includes in the compile of an executable.
           - case: copies-private
             prose: Generating a distribution copies private include headers to private/include.
           - case: skips-install-private

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -36,6 +36,10 @@ plan:
             prose: A library created with one `Distribution` can be linked to an executable in another `Distribution`.
       - group: addLibrary
         plan:
+          - case: default-include
+            prose: By default, an executable includes the `@src/include` directory.
+          - case: default-private-include
+            prose: By default, the `private/include` directory is available for header lookup.
           - case: links-c-cxx-as-cxx
             prose: When a C and C++ source (detected by extension) is given to addLibrary, the executable is linked with a C++ compiler.
           - case: can-link-to-other-distribution

--- a/src/spec/plan.yaml
+++ b/src/spec/plan.yaml
@@ -24,6 +24,8 @@ plan:
             prose: By default, an executable includes the `@src/include` directory.
           - case: header-is-postreq
             prose: Updating a header file required by a compilation makes an executable require updates.
+          - case: default-private-include
+            prose: By default, the `private/include` directory is available for header lookup.
           - case: links-c-cxx-as-cxx
             prose: When a C and C++ source (detected by extension) is given to addExecutable, the executable is linked with a C++ compiler.
           - case: includes-direct-dependency-dirs


### PR DESCRIPTION
This PR adds support for the notion of "private includes".  It does not yet add support for a user defined directory, but is limited to the "private/include" source directory.

The properties of these private includes are:

- Dev builds will have the includes available for compiling
- The headers will be copied into the distribution's `private/include` directory and included via `target_include_directories(... PRIVATE private/include)` in the `CMakeLists.txt`
- The headers will **NOT** be installed with CMake, meaning they won't be available to downstream consumers.